### PR TITLE
feat: server config validation functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ shared.fetchJSON();
 * [arrayToObject(o)](#arrayToObject) ⇒ <code>object</code>
 * [clone(object)](#clone) ⇒ <code>\*</code>
 * [columnNameToVariable(name)](#columnNameToVariable) ⇒ <code>string</code>
+* [configSchema](#configSchema) : <code>object</code>
+
+
 * [deleteJSON(url, callback)](#deleteJSON) ⇒ <code>Promise</code>
 * [equalish(a, b)](#equalish) ⇒ <code>boolean</code>
 * [fetchJSON(url, method, credentials, body, callback)](#fetchJSON) ⇒ <code>Promise</code>
@@ -141,6 +144,49 @@ columnNameToVariable('GDP (per cap.)') // gdp_per_cap
 
 * * *
 
+<a name="configSchema"></a>
+
+### configSchema : <code>object</code>
+`@datawrapper/shared/configSchema` provides a set of useful validation functions for service
+config validation.
+
+> This object is not included with `import shared from "@datawrapper/shared"`.
+> It has a dependency on `Joi` which is quite a big validation library for Node server projects.
+
+Each function returns the configuration object when validation succeeds.
+When validation fails (eg. missing or invalid key) a function will throw a `ValidationError`.
+
+Example function signature: `function validateAPI (config : object) : object`
+
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| validateAPI | <code>function</code> | Validate an API server config |
+| validateORM | <code>function</code> | Validate an ORM initialization config |
+| validateFrontend | <code>function</code> | Validate a frontend server config |
+| validateRenderServer | <code>function</code> | Validate a render server config |
+| validateRenderClient | <code>function</code> | Validate a render client config |
+| validateAll | <code>function</code> | Validate a complete config |
+
+**Example**  
+```js
+// validate complete config
+const { validateAll } = require('@datawrapper/shared/configSchema')
+validateAll(config)
+
+// validate only api config
+const { validateAPI } = require('@datawrapper/shared/configSchema')
+validateAPI(config.api)
+
+// if a service relies on multiple configuration objects but not all. Validate the parts needed.
+const { validateAPI, validateORM } = require('@datawrapper/shared/configSchema')
+validateAPI(config.api)
+validateORM(config.orm)
+```
+
+* * *
+
 <a name="deleteJSON"></a>
 
 ### deleteJSON(url, callback) ⇒ <code>Promise</code>
@@ -255,7 +301,7 @@ checks if a given string is a valid URL
 <a name="loadScript"></a>
 
 ### loadScript(src, callback)
-injects a <script> element to the page to load a new JS script
+injects a `<script>` element to the page to load a new JS script
 
 
 | Param | Type |
@@ -269,7 +315,7 @@ injects a <script> element to the page to load a new JS script
 <a name="loadStylesheet"></a>
 
 ### loadStylesheet(src, callback)
-injects a <link> element to the page to load a new stylesheet
+injects a `<link>` element to the page to load a new stylesheet
 
 
 | Param | Type |

--- a/configSchema.js
+++ b/configSchema.js
@@ -1,0 +1,125 @@
+const Joi = require('joi');
+const chalk = require('chalk');
+
+const schema = {};
+
+schema.API = Joi.object({
+    port: Joi.number()
+        .integer()
+        .default(3000),
+    domain: Joi.string()
+        .hostname()
+        .required(),
+    subdomain: Joi.string(),
+    sessionID: Joi.string().default('DW-SESSION'),
+    https: Joi.boolean(),
+    cors: Joi.array().required(),
+    hashRounds: Joi.number()
+        .integer()
+        .default(15),
+    enableMigration: Joi.boolean(),
+    authSalt: Joi.string(),
+    secretAuthSalt: Joi.string()
+}).unknown();
+
+schema.Frontend = Joi.object()
+    .keys({
+        domain: Joi.string()
+            .hostname()
+            .required(),
+        https: Joi.boolean(),
+        img_domain: Joi.string(),
+        img_cloudflare: Joi.boolean()
+    })
+    .unknown();
+
+schema.ORM = Joi.object()
+    .keys({
+        retry: Joi.boolean().optional(),
+        db: Joi.object()
+            .keys({
+                dialect: Joi.string()
+                    .required()
+                    .default('mysql'),
+                host: Joi.string()
+                    .hostname()
+                    .required(),
+                port: Joi.number()
+                    .integer()
+                    .default(3306),
+                user: Joi.string().required(),
+                password: Joi.string().required(),
+                database: Joi.string().required()
+            })
+            .required()
+    })
+    .unknown();
+
+schema.RenderServer = Joi.object({
+    domain: Joi.string().required(),
+    host: Joi.string()
+        .ip()
+        .required(),
+    port: Joi.number()
+        .integer()
+        .required(),
+    tls: Joi.object({
+        cert: Joi.string(),
+        key: Joi.string(),
+        ca: Joi.string()
+    }).optional(),
+    ec2: Joi.object({
+        region: Joi.string().required(),
+        access_key_id: Joi.string().required(),
+        secret_access_key: Joi.string().required()
+    }).required()
+}).unknown();
+
+schema.RenderClient = Joi.object({
+    max_jobs_before_restart: Joi.number()
+        .integer()
+        .required(),
+    tls: Joi.object({
+        cert: Joi.string(),
+        key: Joi.string(),
+        ca: Joi.string()
+    }),
+    s3: Joi.object({
+        access_key_id: Joi.string().required(),
+        secret_access_key: Joi.string().required()
+    }).required(),
+    cloudflare: Joi.object({
+        zone_id: Joi.string(),
+        auth_email: Joi.string().email(),
+        auth_key: Joi.string()
+    }),
+    cloudfront: Joi.object({
+        distribution_id: Joi.string(),
+        access_key_id: Joi.string(),
+        secret_access_key: Joi.string()
+    })
+}).unknown();
+
+function validate(name, config) {
+    const { error, value } = Joi.validate(config, schema[name], { abortEarly: false });
+
+    if (error) {
+        process.stderr.write(chalk.red(`\n[${name}] config validation failed\n`));
+        error.details.forEach(err => {
+            process.stderr.write(
+                `    [${err.path.join('.')}] ${err.message} | value: ${err.context.value}\n`
+            );
+        });
+        process.exit(1);
+    }
+
+    return value;
+}
+
+const validateFunctions = {};
+
+Object.keys(schema).forEach(key => {
+    validateFunctions[`validate${key}`] = config => validate(key, config);
+});
+
+module.exports = validateFunctions;

--- a/configSchema.test.js
+++ b/configSchema.test.js
@@ -1,0 +1,116 @@
+import test from 'ava';
+import configSchema from './configSchema';
+
+const config = {
+    frontend: {
+        https: false,
+        domain: 'example.de',
+        img_domain: 'img.example.de',
+        img_cloudflare: false
+    },
+    api: {
+        port: 3000,
+        domain: 'example.de',
+        subdomain: 'api',
+        sessionID: 'session',
+        https: false,
+        hashRounds: 15,
+        enableMigration: true,
+        cors: ['*'],
+        authSalt: 'token',
+        secretAuthSalt: 'token'
+    },
+    orm: {
+        retry: true,
+        db: {
+            dialect: 'mysql',
+            host: '127.0.0.1',
+            port: 3306,
+            user: 'user',
+            password: 'password',
+            database: 'database'
+        }
+    },
+    'render-server': {
+        domain: 'render.example.de',
+        host: '0.0.0.0',
+        port: 999
+    },
+    'render-client': {
+        max_jobs_before_restart: 3,
+        s3: {
+            access_key_id: 'token',
+            secret_access_key: 'token'
+        },
+        cloudflare: {
+            zone_id: 'id',
+            auth_email: 'test@example.de',
+            auth_key: 'token'
+        },
+        cloudfront: {
+            distribution_id: 'id',
+            access_key_id: 'token',
+            secret_access_key: 'token'
+        }
+    }
+};
+
+test('validateConfig - should successfully validate', t => {
+    t.notThrows(() => configSchema.validateConfig(config));
+});
+
+test('validateConfig - should throw with invalid config', t => {
+    let invalidConfig = { ...config };
+    invalidConfig.plugins = '';
+    t.throws(() => configSchema.validateConfig(invalidConfig));
+});
+
+test('validateConfig - should throw with wrong top level keys', t => {
+    let invalidConfig = { ...config };
+    invalidConfig.API = '';
+    const error = t.throws(() => configSchema.validateConfig(invalidConfig));
+
+    t.is(error.name, 'ValidationError');
+    t.deepEqual(error.details[0].path, ['API']);
+    t.is(error.details[0].type, 'object.allowUnknown');
+});
+
+test('validateFrontend - should successfully validate', t => {
+    t.notThrows(() => configSchema.validateFrontend(config.frontend));
+});
+
+test('validateFrontend - should throw with invalid config', t => {
+    t.throws(() => configSchema.validateFrontend({}));
+});
+
+test('validateAPI - should successfully validate', t => {
+    t.notThrows(() => configSchema.validateAPI(config.api));
+});
+
+test('validateAPI - should throw with invalid config', t => {
+    t.throws(() => configSchema.validateAPI({}));
+});
+
+test('validateORM - should successfully validate', t => {
+    t.notThrows(() => configSchema.validateORM(config.orm));
+});
+
+test('validateORM - should throw with invalid config', t => {
+    t.throws(() => configSchema.validateORM({}));
+});
+
+test('validateRenderServer - should successfully validate', t => {
+    t.notThrows(() => configSchema.validateRenderServer(config['render-server']));
+});
+
+test('validateRenderServer - should throw with invalid config', t => {
+    t.throws(() => configSchema.validateRenderServer({}));
+});
+
+test('validateRenderClient - should successfully validate', t => {
+    t.notThrows(() => configSchema.validateRenderClient(config['render-client']));
+});
+
+test('validateRenderClient - should throw with invalid config', t => {
+    t.throws(() => configSchema.validateRenderClient({}));
+});

--- a/fetch.js
+++ b/fetch.js
@@ -99,7 +99,7 @@ export function deleteJSON(url, callback) {
 }
 
 /**
- * injects a <script> element to the page to load a new JS script
+ * injects a `<script>` element to the page to load a new JS script
  *
  * @param {string} src
  * @param {function} callback
@@ -114,7 +114,7 @@ export function loadScript(src, callback) {
 }
 
 /**
- * injects a <link> element to the page to load a new stylesheet
+ * injects a `<link>` element to the page to load a new stylesheet
  *
  * @param {string} src
  * @param {function} callback

--- a/package-lock.json
+++ b/package-lock.json
@@ -3459,6 +3459,12 @@
         "standard-engine": "~10.0.0"
       }
     },
+    "hoek": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
+      "dev": true
+    },
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -3957,6 +3963,15 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
+    "isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "dev": true,
+      "requires": {
+        "punycode": "2.x.x"
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3968,6 +3983,17 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "joi": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
+      "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
+      "dev": true,
+      "requires": {
+        "hoek": "6.x.x",
+        "isemail": "3.x.x",
+        "topo": "3.x.x"
+      }
     },
     "js-string-escape": {
       "version": "1.0.1",
@@ -6627,6 +6653,15 @@
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
+      }
+    },
+    "topo": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+      "dev": true,
+      "requires": {
+        "hoek": "6.x.x"
       }
     },
     "toposort": {

--- a/package.json
+++ b/package.json
@@ -33,11 +33,17 @@
     "devDependencies": {
         "ava": "^1.3.1",
         "babel-eslint": "^10.0.1",
+        "chalk": "^2.4.2",
         "healthier": "^2.0.0",
         "husky": "^1.3.1",
+        "joi": "^14.3.1",
         "jsdoc-to-markdown": "^4.0.1",
         "lint-staged": "^8.1.5",
         "prettier": "^1.16.4"
+    },
+    "peerDependencies": {
+        "chalk": "2.x",
+        "joi": "14.x"
     },
     "lint-staged": {
         "*.js": [


### PR DESCRIPTION
Projects like `API`, `ORM`, `render-server`, `render-client` can be configured with a `config.js` file they load on startup.
This PR adds validation functions for separate config keys.

Usage:

```js
const { validateAPI, validateORM } = require('@datawrapper/shared/node/config-schema')

validateAPI(config.api)
validateORM(config.orm)
```

All functions write to `stderr` if a key validation fails and will exit with code 1 in that case.

Exported functions so far:

* `validateAPI`
* `validateORM`
* `validateFrontend`
* `validateRenderServer`
* `validateRenderClient`