### PR TITLE
chore: use scoped joi package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
             - restore_cache:
                   key: v1-install-cache-{{ checksum "package-lock.json" }}
 
-            - run: npm ci && npm install --no-save joi
+            - run: npm ci && npm install --no-save @hapi/joi
 
             - save_cache:
                   <<: *cache

--- a/configSchema.js
+++ b/configSchema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 const chalk = require('chalk');
 
 const schema = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "@datawrapper/shared",
   "version": "0.9.7",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@ava/babel-plugin-throws-helper": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "chroma-js": "^2.0.3"
     },
     "peerDependencies": {
-        "joi": "14.x",
+        "@hapi/joi": "15.x",
         "chalk": "2.x"
     },
     "lint-staged": {


### PR DESCRIPTION
Hapijs switched to scoped packages with `@hapi` scope. Since I'm moving the API to those packages
and want npm to deduplicate as much as possible, I'm going through plugins etc to move to the new packages.