### PR TITLE
add custom error class `CodedError`

### DIFF
--- a/CodedError.js
+++ b/CodedError.js
@@ -1,0 +1,34 @@
+class CodedError extends Error {
+    /**
+     * A custom Error object that allows for storing both an error
+     * code and an error message (the standard JS error only stores
+     * a message). Feel free to use this error whenever you need to
+     * cleanly separate error code from error message.
+     *
+     * @exports CodedError
+     * @kind function
+     *
+     * @example
+     * import { CodedError } from '@datawrapper/shared';
+     * throw new CodedError('notFound', 'the chart was not found');
+     *
+     * @param [string] code    a valid error code (depends on where it's being used). e.g. "notFound"
+     * @param [string] message  an optional plain english message with more details
+     */
+    constructor(code, message) {
+        super(message);
+        this.name = 'CodedError';
+        this.code = code;
+        if (typeof Error.captureStackTrace === 'function') {
+            Error.captureStackTrace(this, this.constructor);
+        } else {
+            this.stack = new Error(message).stack;
+        }
+    }
+
+    toString() {
+        return `[${this.code}] ${this.message}`;
+    }
+}
+
+export default CodedError;

--- a/CodedError.test.js
+++ b/CodedError.test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
-import CodedError from './codedError';
+import CodedError from './CodedError';
 
-test('api error preserves code', t => {
+test('CodedError preserves code', t => {
     const error = new CodedError('notFound', 'the chart was not found');
     t.is(error.code, 'notFound');
     t.is(error.message, 'the chart was not found');

--- a/CodedError.test.js
+++ b/CodedError.test.js
@@ -1,0 +1,11 @@
+import test from 'ava';
+import CodedError from './codedError';
+
+test('api error preserves code', t => {
+    const error = new CodedError('notFound', 'the chart was not found');
+    t.is(error.code, 'notFound');
+    t.is(error.message, 'the chart was not found');
+    t.is(error.name, 'CodedError');
+    t.is(typeof error.stack, 'string');
+    t.is(String(error), '[notFound] the chart was not found');
+});

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ shared.fetchJSON();
 
 
 * [__(key, scope)](#__) ⇒ <code>string</code>
-* [ApiError](#ApiError)
 * [area(vertices)](#area) ⇒ <code>number</code>
 * [arrayToObject(o)](#arrayToObject) ⇒ <code>object</code>
 * [autoTickFormat(column)](#autoTickFormat) ⇒ <code>string</code>
@@ -27,6 +26,7 @@ shared.fetchJSON();
 * [autoTickFormatNumber(range)](#autoTickFormatNumber) ⇒ <code>string</code>
 * [Chart](docs/chart.md) ⇒ <code>class</code>
 * [clone(object)](#clone) ⇒ <code>\*</code>
+* [CodedError([string], [string])](#CodedError)
 * [colorLightness(hexColor)](#colorLightness) ⇒ <code>number</code>
 * [Column](docs/column.md) ⇒ <code>class</code>
 * [columnNameToVariable(name)](#columnNameToVariable) ⇒ <code>string</code>
@@ -41,7 +41,6 @@ shared.fetchJSON();
 * [isValidUrl(input)](#isValidUrl) ⇒ <code>boolean</code>
 * [loadScript(src, callback)](#loadScript)
 * [loadStylesheet(src, callback)](#loadStylesheet)
-* [new ApiError([string], [string])](#new_ApiError_new)
 * [observeFonts(fontsJSON, typographyJSON)](#observeFonts) ⇒ <code>Promise</code>
 * [patchJSON(url, body, callback)](#patchJSON) ⇒ <code>Promise</code>
 * [postEvent(chartId)](#postEvent) ⇒ <code>function</code>
@@ -55,9 +54,25 @@ shared.fetchJSON();
 * [trackPageView(loadTime)](#trackPageView)
 
 
-<a name="ApiError"></a>
+<a name="CodedError"></a>
 
-## ApiError
+## CodedError([string], [string])
+A custom Error object that allows for storing both an error
+code and an error message (the standard JS error only stores
+a message). Feel free to use this error whenever you need to
+cleanly separate error code from error message.
+
+
+| Param | Description |
+| --- | --- |
+| [string] | code    a valid error code (depends on where it's being used). e.g. "notFound" |
+| [string] | message  an optional plain english message with more details |
+
+**Example**  
+```js
+import { CodedError } from '@datawrapper/shared';
+throw new CodedError('notFound', 'the chart was not found');
+```
 
 * * *
 
@@ -473,18 +488,6 @@ loadStylesheet('/static/css/library.css', () => {
     console.log('library styles are loaded');
 })
 ```
-
-* * *
-
-<a name="new_ApiError_new"></a>
-
-#### new ApiError([string], [string])
-
-| Param | Description |
-| --- | --- |
-| [string] | code    a valid @hapijs/boom error code, e.g. "notFound" |
-| [string] | message  an optional plain english message with more details |
-
 
 * * *
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ shared.fetchJSON();
 
 
 * [__(key, scope)](#__) ⇒ <code>string</code>
+* [ApiError](#ApiError)
 * [area(vertices)](#area) ⇒ <code>number</code>
 * [arrayToObject(o)](#arrayToObject) ⇒ <code>object</code>
 * [autoTickFormat(column)](#autoTickFormat) ⇒ <code>string</code>
@@ -40,6 +41,7 @@ shared.fetchJSON();
 * [isValidUrl(input)](#isValidUrl) ⇒ <code>boolean</code>
 * [loadScript(src, callback)](#loadScript)
 * [loadStylesheet(src, callback)](#loadStylesheet)
+* [new ApiError([string], [string])](#new_ApiError_new)
 * [observeFonts(fontsJSON, typographyJSON)](#observeFonts) ⇒ <code>Promise</code>
 * [patchJSON(url, body, callback)](#patchJSON) ⇒ <code>Promise</code>
 * [postEvent(chartId)](#postEvent) ⇒ <code>function</code>
@@ -52,6 +54,12 @@ shared.fetchJSON();
 * [trackEvent(category, category, category, category)](#trackEvent)
 * [trackPageView(loadTime)](#trackPageView)
 
+
+<a name="ApiError"></a>
+
+## ApiError
+
+* * *
 
 <a name="__"></a>
 
@@ -465,6 +473,18 @@ loadStylesheet('/static/css/library.css', () => {
     console.log('library styles are loaded');
 })
 ```
+
+* * *
+
+<a name="new_ApiError_new"></a>
+
+#### new ApiError([string], [string])
+
+| Param | Description |
+| --- | --- |
+| [string] | code    a valid @hapijs/boom error code, e.g. "notFound" |
+| [string] | message  an optional plain english message with more details |
+
 
 * * *
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 export { default as analytics } from './analytics.js';
+export { default as apiError } from './apiError.js';
 export { default as area } from './area.js';
 export { default as arrayToObject } from './arrayToObject.js';
 export { default as autoTickFormat } from './autoTickFormat.js';

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 export { default as analytics } from './analytics.js';
-export { default as apiError } from './apiError.js';
+export { default as CodedError } from './CodedError.js';
 export { default as area } from './area.js';
 export { default as arrayToObject } from './arrayToObject.js';
 export { default as autoTickFormat } from './autoTickFormat.js';


### PR DESCRIPTION
A custom Error object that allows for storing both an error code and an error message (the standard JS error only stores a message). Feel free to use this error whenever you need to cleanly separate error code from error message.

**Example**  
```js
import { CodedError } from '@datawrapper/shared';
throw new CodedError('notFound', 'the chart was not found');
```
