### PR TITLE
Alow target=_self if users sets explicitly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@datawrapper/shared",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@datawrapper/shared",
-    "version": "0.13.1",
+    "version": "0.13.2",
     "description": "shared functions used throughout datawrapper",
     "keywords": [
         "js",

--- a/purifyHtml.js
+++ b/purifyHtml.js
@@ -33,7 +33,7 @@ export default function purifyHTML(input, allowed) {
     for (var i = 0; i < sel.length; i++) {
         if (sel[i].nodeName.toLowerCase() === 'a') {
             // special treatment for <a> elements
-            sel[i].setAttribute('target', '_blank');
+            if (sel[i].getAttribute('target') !== '_self') sel[i].setAttribute('target', '_blank');
             sel[i].setAttribute('rel', 'nofollow noopener noreferrer');
         }
         for (var j = 0; j < sel[i].attributes.length; j++) {

--- a/purifyHtml.test.js
+++ b/purifyHtml.test.js
@@ -40,10 +40,17 @@ test('links get target="_blank" and rel="" set automatically', t => {
     );
 });
 
-test('links with existing target get overwritten', t => {
+test('links with existing target != _self get overwritten', t => {
     t.is(
         purifyHtml('check out <a href="https://example.com" target="_parent">this link</a>!'),
         'check out <a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">this link</a>!'
+    );
+});
+
+test('links with existing target _self dont get overwritten', t => {
+    t.is(
+        purifyHtml('check out <a href="https://example.com" target="_self">this link</a>!'),
+        'check out <a href="https://example.com" target="_self" rel="nofollow noopener noreferrer">this link</a>!'
     );
 });
 


### PR DESCRIPTION
A customer wanted to implement a "reload" button for a table, for which he created a link with `target="_self"`. This was broken due to our implementation of link sanitzing