### PR TITLE
feat: add utility functions to find and require DW config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ shared.fetchJSON();
 * [equalish(a, b)](#equalish) ⇒ <code>boolean</code>
 * [estimateTextWidth(text, fontSize)](#estimateTextWidth) ⇒ <code>number</code>
 * [fetchJSON(url, method, credentials, body, callback)](#fetchJSON) ⇒ <code>Promise</code>
+* [findConfigPath()](#findConfigPath) ⇒ <code>String</code>
 * [get(object, key, _default)](#get) ⇒
 * [getJSON(url, credentials, callback)](#getJSON) ⇒ <code>Promise</code>
 * [highlightTimer(action, delay)](#highlightTimer) ⇒ <code>object</code>
@@ -49,6 +50,7 @@ shared.fetchJSON();
 * [postJSON(url, body, callback)](#postJSON) ⇒ <code>Promise</code>
 * [purifyHTML(input, allowed)](#purifyHTML) ⇒ <code>string</code>
 * [putJSON(url, body, callback)](#putJSON) ⇒ <code>Promise</code>
+* [requireConfig()](#requireConfig) ⇒ <code>Object</code>
 * [round(value, decimals)](#round) ⇒ <code>number</code>
 * [set(object, key, value)](#set) ⇒
 * [significantDimension(values, tolerance)](#significantDimension) ⇒ <code>number</code>
@@ -383,6 +385,28 @@ fetchJSON('http://api.example.org', 'GET', 'include');
 
 * * *
 
+<a name="findConfigPath"></a>
+
+### findConfigPath() ⇒ <code>String</code>
+Function to find a Datawrapper config file (`config.js`).
+It looks in the current working directory and in `/etc/datawrapper/`.
+If no config is found, the process will exit with a non zero exit code.
+
+It is possible to overwrite the config path with the env variable `DW_CONFIG_PATH`.
+Useful for tests!
+
+**This is a Node module, that will probably not work in a browser environment.**
+
+**Example**  
+```js
+const { findConfigPath } = require('@datawrapper/shared/node/findConfig')
+
+const path = findConfigPath()
+// -> /etc/datawrapper/config.js
+```
+
+* * *
+
 <a name="get"></a>
 
 ### get(object, key, _default) ⇒
@@ -667,6 +691,20 @@ putJSON('http://api.example.org', JSON.stringify({
    query: 'foo',
    page: 12
 }));
+```
+
+* * *
+
+<a name="requireConfig"></a>
+
+### requireConfig() ⇒ <code>Object</code>
+Tiny wrapper around `findConfigPath` that directly `require`s the found config.
+
+**Example**  
+```js
+const { requireConfig } = require('@datawrapper/shared/node/findConfig')
+
+const config = requireConfig()
 ```
 
 * * *

--- a/node/findConfig.js
+++ b/node/findConfig.js
@@ -20,11 +20,15 @@ const fs = require('fs');
  * @returns {String}
  */
 function findConfigPath() {
-    const paths = [
-        path.resolve(process.env.DW_CONFIG_PATH),
-        '/etc/datawrapper/config.js',
-        path.join(process.cwd(), 'config.js')
-    ];
+    const customPath = process.env.DW_CONFIG_PATH
+        ? path.resolve(process.env.DW_CONFIG_PATH)
+        : undefined;
+
+    const paths = ['/etc/datawrapper/config.js', path.join(process.cwd(), 'config.js')];
+
+    if (customPath) {
+        paths.unshift(customPath);
+    }
 
     for (const path of paths) {
         if (fs.existsSync(path)) return path;

--- a/node/findConfig.js
+++ b/node/findConfig.js
@@ -1,0 +1,57 @@
+const path = require('path');
+const fs = require('fs');
+
+/**
+ * Function to find a Datawrapper config file (`config.js`).
+ * It looks in the current working directory and in `/etc/datawrapper/`.
+ * If no config is found, the process will exit with a non zero exit code.
+ *
+ * It is possible to overwrite the config path with the env variable `DW_CONFIG_PATH`.
+ * Useful for tests!
+ *
+ * **This is a Node module, that will probably not work in a browser environment.**
+ *
+ * @example
+ * const { findConfigPath } = require('@datawrapper/shared/node/findConfig')
+ *
+ * const path = findConfigPath()
+ * // -> /etc/datawrapper/config.js
+ *
+ * @returns {String}
+ */
+function findConfigPath() {
+    const paths = [
+        path.resolve(process.env.DW_CONFIG_PATH),
+        '/etc/datawrapper/config.js',
+        path.join(process.cwd(), 'config.js')
+    ];
+
+    for (const path of paths) {
+        if (fs.existsSync(path)) return path;
+    }
+
+    process.stderr.write(`
+❌ No config.js found!
+
+Please check if there is a \`config.js\` file in either
+
+\`/etc/datawrapper\` or \`${path.join(process.cwd(), 'config.js')}\`
+`);
+    process.exit(1);
+}
+
+/**
+ * Tiny wrapper around `findConfigPath` that directly `require`s the found config.
+ *
+ * @example
+ * const { requireConfig } = require('@datawrapper/shared/node/findConfig')
+ *
+ * const config = requireConfig()
+ *
+ * @returns {Object}
+ */
+function requireConfig() {
+    return require(findConfigPath());
+}
+
+module.exports = { findConfigPath, requireConfig };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "test": "ava",
         "test:watch": "ava -w",
         "prepublishOnly": "npm test && npm run lint",
-        "docs": "jsdoc2md --template jsdoc2md/README.hbs --files *.js -g grouped --separators | sed '/\\*\\*Kind\\*\\*/d' | sed '/## $/d' | sed 's/## \\([a-z]\\)/### \\1/' > README.md && node jsdoc2md/fixSorting.js"
+        "docs": "jsdoc2md --template jsdoc2md/README.hbs --files *.js --files node/*.js  -g grouped --separators | sed '/\\*\\*Kind\\*\\*/d' | sed '/## $/d' | sed 's/## \\([a-z]\\)/### \\1/' > README.md && node jsdoc2md/fixSorting.js"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Currently we have this code snippet in most node servers (`api`, `frontend`, `render-server`, `render-client`):

```js
const cfgPath = [path.join(process.cwd(), 'config.js'), '/etc/datawrapper/config.js'].reduce(
    (path, test) => {
        return path || (fs.existsSync(test) ? test : false);
    },
    ''
);
```

It finds our `config.js` file which is usually located at `/etc/datawrapper/`. I refactored it a little to support a `DW_CONFIG_PATH` env variable and look first in the mentioned folder.

The config location is not in flux anymore and this simplifies lookup for our node apps.