### PR TITLE
Some additions to defaultColors + readme documentation & tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ shared.fetchJSON();
 * [columnNameToVariable(name)](#columnNameToVariable) ⇒ <code>string</code>
 * [combinations(input)](#combinations) ⇒ <code>Array.&lt;array&gt;</code>
 * [Dataset](docs/dataset.md) ⇒ <code>class</code>
+* [defaultColors(theme)](#defaultColors) ⇒ <code>\*</code>
 * [deleteJSON(url, callback)](#deleteJSON) ⇒ <code>Promise</code>
 * [equalish(a, b)](#equalish) ⇒ <code>boolean</code>
 * [estimateTextWidth(text, fontSize)](#estimateTextWidth) ⇒ <code>number</code>
@@ -285,6 +286,31 @@ combinations(['a', 'b']);
 ```js
 // returns [[1,2,3], [1,2], [1,3], [1], [2,3], [2], [3]]
 combinations([1,2,3])
+```
+
+* * *
+
+<a name="defaultColors"></a>
+
+### defaultColors(theme) ⇒ <code>\*</code>
+defines colors for the various chart elements like axis text, gridlines,
+bar background etc. based on the theme background color, and some other optional theme parameters
+
+**Returns**: <code>\*</code> - -- object with color definitions  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| theme | <code>\*</code> | - theme data for a chart |
+
+**Example**  
+```js
+// returns {"tickText":{"secondary":"#9d9d9d","primary":"#d9d9d9"},"series":"#f1f1f1","value":"#d9d9d9","axis":"#f1f1f1","gridline":"#707070","fallbackBaseColor":"#f1f1f1"}
+defaultColors({"colors": {"background": "#333333"}});
+```
+**Example**  
+```js
+// returns {"tickText":{"secondary":"#ffffff","primary":"#ffffff"},"series":"#ffffff","value":"#fef2e4","axis":"#ffffff","gridline":"#fedeb5","fallbackBaseColor":"#ffffff"}
+defaultColors({"colors": {"bgBlendRatios": {"gridline": 0.5,"tickText": {"primary": 0,"secondary": 0}},"chartContentBaseColor": "#ffffff","background": "#FCB716"}});
 ```
 
 * * *

--- a/defaultColors.js
+++ b/defaultColors.js
@@ -1,23 +1,59 @@
-import { interpolateRgb } from 'd3-interpolate';
 import chroma from 'chroma-js';
+import get from './get';
+
+/**
+ * defines colors for the various chart elements like axis text, gridlines,
+ * bar background etc. based on the theme background color, and some other optional theme parameters
+ *
+ * @exports defaultColors
+ * @kind function
+ *
+ * @example
+ * // returns {"tickText":{"secondary":"#9d9d9d","primary":"#d9d9d9"},"series":"#f1f1f1","value":"#d9d9d9","axis":"#f1f1f1","gridline":"#707070","fallbackBaseColor":"#f1f1f1"}
+ * defaultColors({"colors": {"background": "#333333"}});
+ *
+ * @example
+ * // returns {"tickText":{"secondary":"#ffffff","primary":"#ffffff"},"series":"#ffffff","value":"#fef2e4","axis":"#ffffff","gridline":"#fedeb5","fallbackBaseColor":"#ffffff"}
+ * defaultColors({"colors": {"bgBlendRatios": {"gridline": 0.5,"tickText": {"primary": 0,"secondary": 0}},"chartContentBaseColor": "#ffffff","background": "#FCB716"}});
+
+ * @param {*} theme -- theme data for a chart
+ * @returns {*} -- object with color definitions
+ */
 
 export function defaultColors(theme) {
     const fallback =
-        chroma.contrast(theme.colors.background, '#000000') < 5.5 ? '#f1f1f1' : '#333333';
+        theme.colors.chartContentBaseColor ||
+        (chroma.contrast(theme.colors.background, '#000000') < 5.5 ? '#f1f1f1' : '#333333');
+
     const darkBG = chroma(theme.colors.background).luminance() < 0.5;
+    const bgBlendRatios = {
+        tickText: {
+            secondary: get(theme, 'colors.bgBlendRatios.tickText.secondary', darkBG ? 0.6 : 0.4),
+            primary: get(theme, 'colors.bgBlendRatios.tickText.primary', 0.2)
+        },
+        series: get(theme, 'colors.bgBlendRatios.series', 0),
+        value: get(theme, 'colors.bgBlendRatios.value', 0.2),
+        axis: get(theme, 'colors.bgBlendRatios.axis', 0),
+        gridline: get(theme, 'colors.bgBlendRatios.gridline', 0.82)
+    };
+
     return {
         tickText: {
-            secondary: interpolateRgb(fallback, theme.colors.background)(darkBG ? 0.6 : 0.4),
-            primary: interpolateRgb(fallback, theme.colors.background)(0.2)
+            secondary: chroma
+                .mix(fallback, theme.colors.background, bgBlendRatios.tickText.secondary)
+                .hex(),
+            primary: chroma
+                .mix(fallback, theme.colors.background, bgBlendRatios.tickText.primary)
+                .hex()
         },
 
-        series: fallback,
+        series: chroma.mix(fallback, theme.colors.background, bgBlendRatios.series).hex(),
 
-        value: interpolateRgb(fallback, theme.colors.background)(0.2),
+        value: chroma.mix(fallback, theme.colors.background, bgBlendRatios.value).hex(),
 
-        axis: fallback,
+        axis: chroma.mix(fallback, theme.colors.background, bgBlendRatios.axis).hex(),
 
-        gridline: interpolateRgb(fallback, theme.colors.background)(0.82),
+        gridline: chroma.mix(fallback, theme.colors.background, bgBlendRatios.gridline).hex(),
 
         fallbackBaseColor: fallback
     };

--- a/defaultColors.test.js
+++ b/defaultColors.test.js
@@ -1,0 +1,57 @@
+import test from 'ava';
+import { defaultColors } from './defaultColors';
+
+const tests = [
+    {
+        testName: 'Dark background color defined in theme',
+        theme: {
+            colors: {
+                background: '#333333'
+            }
+        },
+        expectedResult: {
+            tickText: {
+                secondary: '#9d9d9d',
+                primary: '#d9d9d9'
+            },
+            series: '#f1f1f1',
+            value: '#d9d9d9',
+            axis: '#f1f1f1',
+            gridline: '#707070',
+            fallbackBaseColor: '#f1f1f1'
+        }
+    },
+    {
+        testName: 'Custom chart element basecolor,background & blend ratios defined in theme',
+        theme: {
+            colors: {
+                background: '#FCB716',
+                chartContentBaseColor: '#ffffff',
+                bgBlendRatios: {
+                    gridline: 0.5,
+                    tickText: {
+                        primary: 0,
+                        secondary: 0
+                    }
+                }
+            }
+        },
+        expectedResult: {
+            tickText: {
+                secondary: '#ffffff',
+                primary: '#ffffff'
+            },
+            series: '#ffffff',
+            value: '#fef2e4',
+            axis: '#ffffff',
+            gridline: '#fedeb5',
+            fallbackBaseColor: '#ffffff'
+        }
+    }
+];
+
+tests.forEach(function(testData) {
+    test(testData.testName, t => {
+        t.deepEqual(defaultColors(testData.theme), testData.expectedResult);
+    });
+});


### PR DESCRIPTION
This is a function that is in use by all visualization types to define automatic colors for all themable chart elements such as labels, gridlines, bar background etc. In order to ensure that they are legible, for any given background color.

The function is already in use everywhere and this PR does not change the core functionality, however because it was originally hastily added to this repo during the transition to npm it was previously lacking documentation and tests, which this PR adds. This PR also removes the dependency on `d3-interpolate`, and adds two  features:

- Theme can define the 'base color' used for chart elements, which is then mixed with the background accordingly. If undefined, theme will decide on a light or dark one depending on the contrast to background.
- Theme can optionally define its own 'blend ratios', by which the base color is mixed with the background, for the various chart elements. (these were previously hardcoded)

This is my first time contributing here properly so please help with regards to the readme content, not sure I got that right.