### PR TITLE
throw more useful errors in httpReq

### DIFF
--- a/httpReq.js
+++ b/httpReq.js
@@ -50,8 +50,11 @@ export default function httpReq(path, options = {}) {
     }
     return window.fetch(url, opts).then(res => {
         if (raw) return res;
-        if (!res.ok) throw new Error(`[${res.statusCode}] ${res.statusText}`);
-        if (res.statusCode === 204) return; // no content
+        if (!res.ok) {
+            throw new HttpReqError(res);
+        }
+        if (res.status === 204) return; // no content
+
         // trim away the ;charset=utf-8 from content-type
         const contentType = res.headers.get('content-type').split(';')[0];
         if (contentType === 'application/json') {
@@ -126,4 +129,15 @@ function httpReqVerb(method) {
         }
         return httpReq(path, { ...options, method });
     };
+}
+
+class HttpReqError extends Error {
+    constructor(res) {
+        super();
+        this.name = 'HttpReqError';
+        this.status = res.status;
+        this.statusText = res.statusText;
+        this.message = `[${res.status}] ${res.statusText}`;
+        this.response = res;
+    }
 }

--- a/httpReq.js
+++ b/httpReq.js
@@ -50,11 +50,8 @@ export default function httpReq(path, options = {}) {
     }
     return window.fetch(url, opts).then(res => {
         if (raw) return res;
-        if (!res.ok) {
-            throw new HttpReqError(res);
-        }
+        if (!res.ok) throw new HttpReqError(res);
         if (res.status === 204) return; // no content
-
         // trim away the ;charset=utf-8 from content-type
         const contentType = res.headers.get('content-type').split(';')[0];
         if (contentType === 'application/json') {

--- a/httpReq.test.js
+++ b/httpReq.test.js
@@ -59,6 +59,13 @@ test('post request with csv body', async t => {
     t.falsy(res.json);
 });
 
+test('no content in 204 requests', async t => {
+    const res = await httpReq.get('/status/204', {
+        baseUrl
+    });
+    t.is(res, undefined);
+});
+
 test('throws nice HttpReqError errors', async t => {
     try {
         await httpReq.get('/status/404', {

--- a/httpReq.test.js
+++ b/httpReq.test.js
@@ -58,3 +58,17 @@ test('post request with csv body', async t => {
     t.is(res.data, body);
     t.falsy(res.json);
 });
+
+test('throws nice HttpReqError errors', async t => {
+    try {
+        await httpReq.get('/status/404', {
+            baseUrl
+        });
+    } catch (err) {
+        t.is(err.name, 'HttpReqError');
+        t.is(err.status, 404);
+        t.is(err.statusText, 'NOT FOUND');
+        const body = await err.response.text();
+        t.is(body, '');
+    }
+});


### PR DESCRIPTION
before this PR, `httpReq` would just throw a pretty useless Error with a message of `[statusCode] statusText`. Even worse, due to a bug that slipped through the statusCode in said message was always `undefined` (because it's called `res.status` instead of `res.statusCode`).

Instead, this PR introduces a new custom error object `HttpReqError` that gets initialized with the http response object and exposes some useful properties (e.g. `error.status` for the http status code) as well as the raw response object (which can be used to obtain the json body).

```js
try {
    await httpReq(url, options);
} catch (error) {
   if (error.name === 'HttpReqError') {
       // do cool stuff
       const body = await error.response.json();
       logger.error(`The request returned ${error.status}`, body);
   } else {
       // for other errors 
       logger.error(`Some unexpected error: ${error}`);
   }
}
``` 