### PR TITLE
Allow target=_parent

### DIFF
--- a/purifyHtml.js
+++ b/purifyHtml.js
@@ -33,7 +33,8 @@ export default function purifyHTML(input, allowed) {
     for (var i = 0; i < sel.length; i++) {
         if (sel[i].nodeName.toLowerCase() === 'a') {
             // special treatment for <a> elements
-            if (sel[i].getAttribute('target') !== '_self') sel[i].setAttribute('target', '_blank');
+            if (['_self', '_parent'].indexOf(sel[i].getAttribute('target')) === -1)
+                sel[i].setAttribute('target', '_blank');
             sel[i].setAttribute('rel', 'nofollow noopener noreferrer');
             if (
                 sel[i].getAttribute('href') &&

--- a/purifyHtml.test.js
+++ b/purifyHtml.test.js
@@ -40,10 +40,17 @@ test('links get target="_blank" and rel="" set automatically', t => {
     );
 });
 
-test('links with existing target != _self get overwritten', t => {
+test('links with existing target != _self && != _parent get overwritten', t => {
+    t.is(
+        purifyHtml('check out <a href="https://example.com" target="something">this link</a>!'),
+        'check out <a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">this link</a>!'
+    );
+});
+
+test('links with existing target _parent dont get overwritten', t => {
     t.is(
         purifyHtml('check out <a href="https://example.com" target="_parent">this link</a>!'),
-        'check out <a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">this link</a>!'
+        'check out <a href="https://example.com" target="_parent" rel="nofollow noopener noreferrer">this link</a>!'
     );
 });
 


### PR DESCRIPTION
So that users can link to other places in the embedding page from within a chart. See [notion ticket](https://www.notion.so/datawrapper/Allow-links-to-set-target-_parent-1253470923f048a9a0ebd9cef978e6c3) here.