### PR TITLE
feat: make findConfigPath aware of Docker setups

### DIFF
--- a/node/findConfig.js
+++ b/node/findConfig.js
@@ -24,7 +24,11 @@ function findConfigPath() {
         ? path.resolve(process.env.DW_CONFIG_PATH)
         : undefined;
 
-    const paths = ['/etc/datawrapper/config.js', path.join(process.cwd(), 'config.js')];
+    const paths = [
+        '/etc/datawrapper/config.js',
+        path.join(process.cwd(), '../../', 'config.js'),
+        path.join(process.cwd(), 'config.js')
+    ];
 
     if (customPath) {
         paths.unshift(customPath);

--- a/node/findConfig.js
+++ b/node/findConfig.js
@@ -43,7 +43,7 @@ function findConfigPath() {
 
 Please check if there is a \`config.js\` file in either
 
-\`/etc/datawrapper\` or \`${path.join(process.cwd(), 'config.js')}\`
+${paths.join('\n')}
 `);
     process.exit(1);
 }


### PR DESCRIPTION
This makes services aware of the `core` repositories config path, when `requireConfig` or `findConfigPath` are called on the host machine.

**Why?**

The new `frontend` service is running `npm run build` after installing dependencies. That means when a developer does `npm install`, the script would fail because `npm run build` can't find the config (required in `rollup.config.js`) two directories up. This is usually happening on their host machine and not inside Docker (where the config is located at `/etc/datawrapper/config.js`).

> **It would be cool if our `findConfig.js` would find the config in the core directory**
> *- Quote: David K*