### PR TITLE
Check if content-type is set in httpReq

### DIFF
--- a/httpReq.js
+++ b/httpReq.js
@@ -51,7 +51,7 @@ export default function httpReq(path, options = {}) {
     return window.fetch(url, opts).then(res => {
         if (raw) return res;
         if (!res.ok) throw new HttpReqError(res);
-        if (res.status === 204 || !res.headers.get('content-type')) return; // no content
+        if (res.status === 204 || !res.headers.get('content-type')) return res; // no content
         // trim away the ;charset=utf-8 from content-type
         const contentType = res.headers.get('content-type').split(';')[0];
         if (contentType === 'application/json') {

--- a/httpReq.js
+++ b/httpReq.js
@@ -51,7 +51,7 @@ export default function httpReq(path, options = {}) {
     return window.fetch(url, opts).then(res => {
         if (raw) return res;
         if (!res.ok) throw new HttpReqError(res);
-        if (res.status === 204) return; // no content
+        if (res.status === 204 || !res.headers.get('content-type')) return; // no content
         // trim away the ;charset=utf-8 from content-type
         const contentType = res.headers.get('content-type').split(';')[0];
         if (contentType === 'application/json') {

--- a/httpReq.test.js
+++ b/httpReq.test.js
@@ -63,7 +63,8 @@ test('no content in 204 requests', async t => {
     const res = await httpReq.get('/status/204', {
         baseUrl
     });
-    t.is(res, undefined);
+
+    t.is(res.headers.get('content-length'), null);
 });
 
 test('throws nice HttpReqError errors', async t => {


### PR DESCRIPTION
This is a small update to `httpReq`. It adds a check for whether the response contains `content-type` before trying to parse it. 

Without this additional check, there is at least one current situation which would lead to an error when using `httpReq`: [in `chart-data-s3` we return response code `201` if asset file does not exist yet](https://github.com/datawrapper/plugin-chart-data-s3/blob/df99147a0372cde067d47df789836087a1eaebdf/api.js#L64). But no content is returned and no `content-type` is set, so an error would occur here. The change in this PR fixes this.

In general, I think it's good to check whether `content-type` has actually been set before we do anything with it, no matter what response code is received.