### PR TITLE
Fix significantDimension function

### DIFF
--- a/significantDimension.js
+++ b/significantDimension.js
@@ -1,6 +1,7 @@
 import tailLength from './tailLength';
 import round from './round';
 import uniq from 'lodash-es/uniq';
+import _isFinite from 'lodash-es/isFinite';
 
 /**
  * computes the significant dimension for a list of numbers
@@ -21,7 +22,7 @@ import uniq from 'lodash-es/uniq';
 export default function significantDimension(values, tolerance = 0.1) {
     let result = [];
     let decimals = 0;
-    const uniqValues = uniq(values);
+    const uniqValues = uniq(values.filter(_isFinite));
     const totalUniq = uniqValues.length;
     let check, diff;
 


### PR DESCRIPTION
We all know, and haven't paid much attention to this this rather ugly but otherwise mostly harmless bug, but given this is one of the first things users might see, I thought it might be time to investigate. Looks like the fix was pretty simple.

Before:
![image](https://user-images.githubusercontent.com/19191012/87581915-fa6ef500-c6d9-11ea-94c8-f7d1eb7fee33.png)

After:
![image](https://user-images.githubusercontent.com/19191012/87581976-0fe41f00-c6da-11ea-9eb9-7a90ccc84cca.png)
