### PR TITLE
Add authentication functions

### DIFF
--- a/node/auth.js
+++ b/node/auth.js
@@ -2,382 +2,387 @@ const Boom = require('@hapi/boom');
 const generate = require('nanoid/generate');
 const crypto = require('crypto');
 const bcrypt = require('bcryptjs');
-const { AccessToken, User, Session, Chart } = require('@datawrapper/orm/models');
 
 const DEFAULT_SALT = 'uRPAqgUJqNuBdW62bmq3CLszRFkvq4RW';
 
-function adminValidation({ artifacts } = {}) {
-    if (artifacts.role !== 'admin') {
-        throw Boom.unauthorized('ADMIN_ROLE_REQUIRED');
-    }
-}
-
-function cookieTTL(days) {
-    return 1000 * 3600 * 24 * days; // 1000ms = 1s -> 3600s = 1h -> 24h = 1d
-}
-
-async function getUser(userId, { credentials, strategy, logger } = {}) {
-    let user = await User.findByPk(userId, {
-        attributes: [
-            'id',
-            'email',
-            'role',
-            'language',
-            'activate_token',
-            'reset_password_token',
-            'deleted'
-        ]
-    });
-
-    if (user && user.deleted) {
-        return { isValid: false, message: Boom.unauthorized('User not found', strategy) };
+module.exports = function createAuth({ AccessToken, User, Session, Chart }) {
+    function adminValidation({ artifacts } = {}) {
+        if (artifacts.role !== 'admin') {
+            throw Boom.unauthorized('ADMIN_ROLE_REQUIRED');
+        }
     }
 
-    if (!user && credentials.session) {
-        const notSupported = name => {
-            return () => {
-                logger && logger.warn(`user.${name} is not supported for guests`);
-                return false;
-            };
-        };
-        // use non-persistant User model instance
-        user = User.build({
-            role: 'guest',
-            id: undefined,
-            language: 'en-US'
+    function cookieTTL(days) {
+        return 1000 * 3600 * 24 * days; // 1000ms = 1s -> 3600s = 1h -> 24h = 1d
+    }
+
+    async function getUser(userId, { credentials, strategy, logger } = {}) {
+        let user = await User.findByPk(userId, {
+            attributes: [
+                'id',
+                'email',
+                'role',
+                'language',
+                'activate_token',
+                'reset_password_token',
+                'deleted'
+            ]
         });
-        // make sure it never ends up in our DB
-        user.save = notSupported('save');
-        user.update = notSupported('update');
-        user.destroy = notSupported('destroy');
-        user.reload = notSupported('reload');
+
+        if (user && user.deleted) {
+            return { isValid: false, message: Boom.unauthorized('User not found', strategy) };
+        }
+
+        if (!user && credentials.session) {
+            const notSupported = name => {
+                return () => {
+                    logger && logger.warn(`user.${name} is not supported for guests`);
+                    return false;
+                };
+            };
+            // use non-persistant User model instance
+            user = User.build({
+                role: 'guest',
+                id: undefined,
+                language: 'en-US'
+            });
+            // make sure it never ends up in our DB
+            user.save = notSupported('save');
+            user.update = notSupported('update');
+            user.destroy = notSupported('destroy');
+            user.reload = notSupported('reload');
+        }
+
+        return { isValid: true, credentials, artifacts: user };
     }
 
-    return { isValid: true, credentials, artifacts: user };
-};
-
-
-/**
- * Generate a sha256 hash from a string. This is used in the PHP API and is needed for backwards
- * compatibility.
- *
- * @param {string} pwhash - value to hash with sha256
- * @param {string} secret - salt to hash the value with
- * @returns {string}
- */
-function legacyHash(pwhash, secret = DEFAULT_SALT) {
-    const hmac = crypto.createHmac('sha256', secret);
-    hmac.update(pwhash);
-    return hmac.digest('hex');
-}
-
-/**
- * The old PHP API used sha256 to hash passwords with constant salts.
- * The Node.js API uses bcrypt which is more secure.
- * It is still important to support the old way for migration purposes since PHP and Node API
- * will live side by side for some time.
- * When the PHP Server gets turned off, we can hopefully delete this function.
- *
- * @deprecated
- * @param {string} password - Password string sent from the client (Can be client side hashed or not)
- * @param {string} passwordHash - Password hash to compare (from DB)
- * @param {string} authSalt - defined in config.js
- * @param {string} secretAuthSalt - defined in config.js
- * @returns {boolean}
- */
-function legacyLogin(password, passwordHash, authSalt, secretAuthSalt) {
-    let serverHash = secretAuthSalt ? legacyHash(password, secretAuthSalt) : password;
-
-    if (serverHash === passwordHash) return true;
-
-    const clientHash = legacyHash(password, authSalt);
-    serverHash = secretAuthSalt ? legacyHash(clientHash, secretAuthSalt) : clientHash;
-    return serverHash === passwordHash;
-}
-
-/**
- * Migrate the old sha256 password hash to a more modern and secure bcrypt hash.
- *
- * @param {number} userId - ID of the user to migrate
- * @param {string} password - User password
- * @param {number} hashRounds - Iteration amout for bcrypt
- */
-async function migrateHashToBcrypt(userId, password, hashRounds) {
-    const hash = await bcrypt.hash(password, hashRounds);
-
-    await User.update(
-        {
-            pwd: hash
-        },
-        { where: { id: userId } }
-    );
-}
-
-/**
- * Hash a password with bcrypt. This function doesn't need to be directly imported since it's
- * exposed on the Hapi server object as server method.
- *
- * @example
- * const hash = await server.methods.hashPassword('hunter2')
- *
- * @param {number} hashRounds - Number of rounds for the brypt algorithm
- */
-function createHashPassword(hashRounds) {
-    return async function hashPassword(password) {
-        return password === '' ? password : bcrypt.hash(password, hashRounds);
-    };
-}
-
-function createComparePassword(server) {
     /**
-     * Check validity of a password against the saved password hash
+     * Generate a sha256 hash from a string. This is used in the PHP API and is needed for backwards
+     * compatibility.
      *
-     * @param {string} password - Plaintext password to check
-     * @param {string} passwordHash - Password hash to compare (from DB)
-     * @param {object} options
-     * @param {number} options.userId - User ID for hash migration
-     * @returns {Boolean}
+     * @param {string} pwhash - value to hash with sha256
+     * @param {string} secret - salt to hash the value with
+     * @returns {string}
      */
-    return async function comparePassword(password, passwordHash, { userId }) {
-        const { api } = server.methods.config();
-        let isValid = false;
+    function legacyHash(pwhash, secret = DEFAULT_SALT) {
+        const hmac = crypto.createHmac('sha256', secret);
+        hmac.update(pwhash);
+        return hmac.digest('hex');
+    }
+
+    /**
+     * The old PHP API used sha256 to hash passwords with constant salts.
+     * The Node.js API uses bcrypt which is more secure.
+     * It is still important to support the old way for migration purposes since PHP and Node API
+     * will live side by side for some time.
+     * When the PHP Server gets turned off, we can hopefully delete this function.
+     *
+     * @deprecated
+     * @param {string} password - Password string sent from the client (Can be client side hashed or not)
+     * @param {string} passwordHash - Password hash to compare (from DB)
+     * @param {string} authSalt - defined in config.js
+     * @param {string} secretAuthSalt - defined in config.js
+     * @returns {boolean}
+     */
+    function legacyLogin(password, passwordHash, authSalt, secretAuthSalt) {
+        let serverHash = secretAuthSalt ? legacyHash(password, secretAuthSalt) : password;
+
+        if (serverHash === passwordHash) return true;
+
+        const clientHash = legacyHash(password, authSalt);
+        serverHash = secretAuthSalt ? legacyHash(clientHash, secretAuthSalt) : clientHash;
+        return serverHash === passwordHash;
+    }
+
+    /**
+     * Migrate the old sha256 password hash to a more modern and secure bcrypt hash.
+     *
+     * @param {number} userId - ID of the user to migrate
+     * @param {string} password - User password
+     * @param {number} hashRounds - Iteration amout for bcrypt
+     */
+    async function migrateHashToBcrypt(userId, password, hashRounds) {
+        const hash = await bcrypt.hash(password, hashRounds);
+
+        await User.update(
+            {
+                pwd: hash
+            },
+            { where: { id: userId } }
+        );
+    }
+
+    /**
+     * Hash a password with bcrypt. This function doesn't need to be directly imported since it's
+     * exposed on the Hapi server object as server method.
+     *
+     * @example
+     * const hash = await server.methods.hashPassword('hunter2')
+     *
+     * @param {number} hashRounds - Number of rounds for the brypt algorithm
+     */
+    function createHashPassword(hashRounds) {
+        return async function hashPassword(password) {
+            return password === '' ? password : bcrypt.hash(password, hashRounds);
+        };
+    }
+
+    function createComparePassword(server) {
         /**
-         * Bcrypt uses a prefix for versioning. That way a bcrypt hash can be identified with "$2".
-         * https://en.wikipedia.org/wiki/Bcrypt#Description
+         * Check validity of a password against the saved password hash
+         *
+         * @param {string} password - Plaintext password to check
+         * @param {string} passwordHash - Password hash to compare (from DB)
+         * @param {object} options
+         * @param {number} options.userId - User ID for hash migration
+         * @returns {Boolean}
          */
-        if (passwordHash.startsWith('$2')) {
-            isValid = await bcrypt.compare(password, passwordHash);
+        return async function comparePassword(password, passwordHash, { userId }) {
+            const { api } = server.methods.config();
+            let isValid = false;
             /**
-             * Due to the migration from sha256 to bcrypt, the API must deal with sha256 passwords that
-             * got created by the PHP API and migrated from the `migrateHashToBcrypt` function.
-             * The node API get's passwords only in clear text and to compare those with a migrated
-             * password, it first has to generate the former client hashed password.
+             * Bcrypt uses a prefix for versioning. That way a bcrypt hash can be identified with "$2".
+             * https://en.wikipedia.org/wiki/Bcrypt#Description
              */
-            if (!isValid) {
-                isValid = await bcrypt.compare(legacyHash(password, api.authSalt), passwordHash);
-            }
-        } else {
-            /**
-             * The user password hash was created by the PHP API and is not a bcrypt hash. That means
-             * the API needs to use the old comparison method with double sha256 hashes.
-             */
-            isValid = legacyLogin(password, passwordHash, api.authSalt, api.secretAuthSalt);
-
-            /**
-             * When the old method works, the API migrates the old hash to a bcrypt hash for more
-             * security. This ensures a seemless migration for users.
-             */
-            if (isValid && userId && api.enableMigration) {
-                await migrateHashToBcrypt(userId, password, api.hashRounds);
-            }
-        }
-        return isValid;
-    };
-}
-
-function getStateOpts(
-    server,
-    ttl,
-    sameSite = process.env.NODE_ENV === 'development' ? 'None' : 'Lax'
-) {
-    return {
-        isSecure: server.methods.config('frontend').https,
-        strictHeader: false,
-        domain: `.${server.methods.config('api').domain}`,
-        isSameSite: sameSite,
-        path: '/',
-        ttl: cookieTTL(ttl)
-    };
-}
-
-async function associateChartsWithUser(sessionId, userId) {
-    /* Sequelize returns [0] when no row was updated */
-    if (!sessionId) return [0];
-
-    return Chart.update(
-        {
-            author_id: userId,
-            guest_session: null
-        },
-        {
-            where: {
-                author_id: null,
-                guest_session: sessionId
-            }
-        }
-    );
-}
-
-async function createSession(id, userId, keepSession = true, type = 'password') {
-    return Session.create({
-        id,
-        user_id: userId,
-        persistent: keepSession,
-        data: {
-            'dw-user-id': userId,
-            persistent: keepSession,
-            last_action_time: Math.floor(Date.now() / 1000),
-            type
-        }
-    });
-}
-
-async function bearerValidation(request, token, h) {
-    const row = await AccessToken.findOne({ where: { token, type: 'api-token' } });
-
-    if (!row) {
-        return { isValid: false, message: Boom.unauthorized('Token not found', 'Token') };
-    }
-
-    await row.update({ last_used_at: new Date() });
-
-    const auth = await getUser(row.user_id, {
-        credentials: { token },
-        strategy: 'Token'
-    });
-    if (!auth.artifacts.isActivated()) {
-        // only activated users may authenticate through bearer tokens
-        return { isValid: false, message: Boom.unauthorized('User not activated', 'Token') };
-    }
-    if (auth.isValid) {
-        auth.credentials.scope =
-            !row.data.scopes || row.data.scopes.includes('all')
-                ? request.server.methods.getScopes(auth.artifacts.isAdmin())
-                : row.data.scopes;
-    }
-    return auth;
-}
-
-async function cookieValidation(request, session, h) {
-    let row = await Session.findByPk(session);
-
-    if (!row) {
-        return { isValid: false, message: Boom.unauthorized('Session not found', 'Session') };
-    }
-
-    row = await row.update({
-        data: {
-            ...row.data,
-            last_action_time: Math.floor(Date.now() / 1000)
-        }
-    });
-
-    const auth = await getUser(row.data['dw-user-id'], {
-        credentials: { session, data: row },
-        strategy: 'Session',
-        logger: typeof request.server.logger === 'function' ? request.server.logger() : undefined
-    });
-
-    if (auth.isValid) {
-        if (typeof request.server.methods.getScopes === 'function') {
-            // add all scopes to cookie session
-            auth.credentials.scope = request.server.methods.getScopes(auth.artifacts.isAdmin());
-        }
-
-        auth.sessionType = row.data.type;
-    }
-    return auth;
-}
-
-function createCookieAuthScheme(createGuestSessions) {
-    return function cookieAuth(server, options) {
-        const api = server.methods.config('api');
-        const opts = { cookie: api.sessionID, ...options };
-
-        server.state(opts.cookie, getStateOpts(server, 90));
-
-        const scheme = {
-            authenticate: async (request, h) => {
-                let session = request.state[opts.cookie];
+            if (passwordHash.startsWith('$2')) {
+                isValid = await bcrypt.compare(password, passwordHash);
+                /**
+                 * Due to the migration from sha256 to bcrypt, the API must deal with sha256 passwords that
+                 * got created by the PHP API and migrated from the `migrateHashToBcrypt` function.
+                 * The node API get's passwords only in clear text and to compare those with a migrated
+                 * password, it first has to generate the former client hashed password.
+                 */
+                if (!isValid) {
+                    isValid = await bcrypt.compare(
+                        legacyHash(password, api.authSalt),
+                        passwordHash
+                    );
+                }
+            } else {
+                /**
+                 * The user password hash was created by the PHP API and is not a bcrypt hash. That means
+                 * the API needs to use the old comparison method with double sha256 hashes.
+                 */
+                isValid = legacyLogin(password, passwordHash, api.authSalt, api.secretAuthSalt);
 
                 /**
-                 * Sometimes there are 2 session cookies, in the staging environment, with name
-                 * DW-SESSION. The reason is that the same name is used on live (.datawrapper.de) and
-                 * staging (.staging.datawrapper.de). The cookie parser therefore returns an array with
-                 * both cookies and since the server doesn't send any information which cookie belongs
-                 * to which domain, the code relies on the server sending the more specific cookie
-                 * first. This is fine since it only happens on staging and the quick fix is to delete
-                 * the wrong cookie in dev tools.
-                 *
-                 * More information and a similar issue can be found on Github:
-                 * https://github.com/jshttp/cookie/issues/18#issuecomment-30344206
+                 * When the old method works, the API migrates the old hash to a bcrypt hash for more
+                 * security. This ensures a seemless migration for users.
                  */
-                if (Array.isArray(session)) {
-                    session = session[0];
-                }
-
-                const {
-                    isValid,
-                    credentials,
-                    artifacts,
-                    sessionType,
-                    message = Boom.unauthorized(null, 'Session')
-                } = await cookieValidation(request, session, h);
-
-                const sameSite = process.env.NODE_ENV === 'development' ? 'None' : 'Lax';
-
-                if (isValid) {
-                    h.state(
-                        opts.cookie,
-                        session,
-                        getStateOpts(server, 90, sessionType === 'token' ? 'None' : sameSite)
-                    );
-                    return h.authenticated({ credentials, artifacts });
-                } else if (createGuestSessions) {
-                    // no cookie or session expired, let's create a new session
-                    const sessionId = generateToken();
-
-                    const session = await Session.create({
-                        id: sessionId,
-                        user_id: null,
-                        persistent: false,
-                        data: {
-                            'dw-user-id': null,
-                            persistent: false,
-                            last_action_time: Math.floor(Date.now() / 1000)
-                        }
-                    });
-
-                    h.state(
-                        opts.cookie,
-                        sessionId,
-                        getStateOpts(server, 90, sessionType === 'token' ? 'None' : sameSite)
-                    );
-
-                    const auth = await getUser('guest', {
-                        credentials: { session: session.id, data: session },
-                        strategy: 'Session'
-                    });
-
-                    return h.authenticated(auth);
-                }
-
-                return message;
-
-                function generateToken(length = 25) {
-                    const alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
-                    return generate(alphabet, length);
+                if (isValid && userId && api.enableMigration) {
+                    await migrateHashToBcrypt(userId, password, api.hashRounds);
                 }
             }
+            return isValid;
         };
-
-        return scheme;
     }
-}
 
-module.exports = {
-    getUser,
-    adminValidation,
-    cookieTTL,
+    function getStateOpts(
+        server,
+        ttl,
+        sameSite = process.env.NODE_ENV === 'development' ? 'None' : 'Lax'
+    ) {
+        return {
+            isSecure: server.methods.config('frontend').https,
+            strictHeader: false,
+            domain: `.${server.methods.config('api').domain}`,
+            isSameSite: sameSite,
+            path: '/',
+            ttl: cookieTTL(ttl)
+        };
+    }
 
-    cookieValidation,
-    createCookieAuthScheme,
-    bearerValidation,
+    async function associateChartsWithUser(sessionId, userId) {
+        /* Sequelize returns [0] when no row was updated */
+        if (!sessionId) return [0];
 
-    legacyHash,
-    createHashPassword,
-    createComparePassword,
-    getStateOpts,
-    associateChartsWithUser,
-    createSession
+        return Chart.update(
+            {
+                author_id: userId,
+                guest_session: null
+            },
+            {
+                where: {
+                    author_id: null,
+                    guest_session: sessionId
+                }
+            }
+        );
+    }
+
+    async function createSession(id, userId, keepSession = true, type = 'password') {
+        return Session.create({
+            id,
+            user_id: userId,
+            persistent: keepSession,
+            data: {
+                'dw-user-id': userId,
+                persistent: keepSession,
+                last_action_time: Math.floor(Date.now() / 1000),
+                type
+            }
+        });
+    }
+
+    async function bearerValidation(request, token, h) {
+        const row = await AccessToken.findOne({ where: { token, type: 'api-token' } });
+
+        if (!row) {
+            return { isValid: false, message: Boom.unauthorized('Token not found', 'Token') };
+        }
+
+        await row.update({ last_used_at: new Date() });
+
+        const auth = await getUser(row.user_id, {
+            credentials: { token },
+            strategy: 'Token'
+        });
+        if (!auth.artifacts.isActivated()) {
+            // only activated users may authenticate through bearer tokens
+            return { isValid: false, message: Boom.unauthorized('User not activated', 'Token') };
+        }
+        if (auth.isValid) {
+            auth.credentials.scope =
+                !row.data.scopes || row.data.scopes.includes('all')
+                    ? request.server.methods.getScopes(auth.artifacts.isAdmin())
+                    : row.data.scopes;
+        }
+        return auth;
+    }
+
+    async function cookieValidation(request, session, h) {
+        let row = await Session.findByPk(session);
+
+        if (!row) {
+            return { isValid: false, message: Boom.unauthorized('Session not found', 'Session') };
+        }
+
+        row = await row.update({
+            data: {
+                ...row.data,
+                last_action_time: Math.floor(Date.now() / 1000)
+            }
+        });
+
+        const auth = await getUser(row.data['dw-user-id'], {
+            credentials: { session, data: row },
+            strategy: 'Session',
+            logger:
+                typeof request.server.logger === 'function' ? request.server.logger() : undefined
+        });
+
+        if (auth.isValid) {
+            if (typeof request.server.methods.getScopes === 'function') {
+                // add all scopes to cookie session
+                auth.credentials.scope = request.server.methods.getScopes(auth.artifacts.isAdmin());
+            }
+
+            auth.sessionType = row.data.type;
+        }
+        return auth;
+    }
+
+    function createCookieAuthScheme(createGuestSessions) {
+        return function cookieAuth(server, options) {
+            const api = server.methods.config('api');
+            const opts = { cookie: api.sessionID, ...options };
+
+            server.state(opts.cookie, getStateOpts(server, 90));
+
+            const scheme = {
+                authenticate: async (request, h) => {
+                    let session = request.state[opts.cookie];
+
+                    /**
+                     * Sometimes there are 2 session cookies, in the staging environment, with name
+                     * DW-SESSION. The reason is that the same name is used on live (.datawrapper.de) and
+                     * staging (.staging.datawrapper.de). The cookie parser therefore returns an array with
+                     * both cookies and since the server doesn't send any information which cookie belongs
+                     * to which domain, the code relies on the server sending the more specific cookie
+                     * first. This is fine since it only happens on staging and the quick fix is to delete
+                     * the wrong cookie in dev tools.
+                     *
+                     * More information and a similar issue can be found on Github:
+                     * https://github.com/jshttp/cookie/issues/18#issuecomment-30344206
+                     */
+                    if (Array.isArray(session)) {
+                        session = session[0];
+                    }
+
+                    const {
+                        isValid,
+                        credentials,
+                        artifacts,
+                        sessionType,
+                        message = Boom.unauthorized(null, 'Session')
+                    } = await cookieValidation(request, session, h);
+
+                    const sameSite = process.env.NODE_ENV === 'development' ? 'None' : 'Lax';
+
+                    if (isValid) {
+                        h.state(
+                            opts.cookie,
+                            session,
+                            getStateOpts(server, 90, sessionType === 'token' ? 'None' : sameSite)
+                        );
+                        return h.authenticated({ credentials, artifacts });
+                    } else if (createGuestSessions) {
+                        // no cookie or session expired, let's create a new session
+                        const sessionId = generateToken();
+
+                        const session = await Session.create({
+                            id: sessionId,
+                            user_id: null,
+                            persistent: false,
+                            data: {
+                                'dw-user-id': null,
+                                persistent: false,
+                                last_action_time: Math.floor(Date.now() / 1000)
+                            }
+                        });
+
+                        h.state(
+                            opts.cookie,
+                            sessionId,
+                            getStateOpts(server, 90, sessionType === 'token' ? 'None' : sameSite)
+                        );
+
+                        const auth = await getUser('guest', {
+                            credentials: { session: session.id, data: session },
+                            strategy: 'Session'
+                        });
+
+                        return h.authenticated(auth);
+                    }
+
+                    return message;
+
+                    function generateToken(length = 25) {
+                        const alphabet =
+                            '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+                        return generate(alphabet, length);
+                    }
+                }
+            };
+
+            return scheme;
+        };
+    }
+
+    return {
+        getUser,
+        adminValidation,
+        cookieTTL,
+
+        cookieValidation,
+        createCookieAuthScheme,
+        bearerValidation,
+
+        legacyHash,
+        createHashPassword,
+        createComparePassword,
+        getStateOpts,
+        associateChartsWithUser,
+        createSession
+    };
 };

--- a/node/auth.js
+++ b/node/auth.js
@@ -1,0 +1,383 @@
+const Boom = require('@hapi/boom');
+const generate = require('nanoid/generate');
+const crypto = require('crypto');
+const bcrypt = require('bcryptjs');
+const { AccessToken, User, Session, Chart } = require('@datawrapper/orm/models');
+
+const DEFAULT_SALT = 'uRPAqgUJqNuBdW62bmq3CLszRFkvq4RW';
+
+function adminValidation({ artifacts } = {}) {
+    if (artifacts.role !== 'admin') {
+        throw Boom.unauthorized('ADMIN_ROLE_REQUIRED');
+    }
+}
+
+function cookieTTL(days) {
+    return 1000 * 3600 * 24 * days; // 1000ms = 1s -> 3600s = 1h -> 24h = 1d
+}
+
+async function getUser(userId, { credentials, strategy, logger } = {}) {
+    let user = await User.findByPk(userId, {
+        attributes: [
+            'id',
+            'email',
+            'role',
+            'language',
+            'activate_token',
+            'reset_password_token',
+            'deleted'
+        ]
+    });
+
+    if (user && user.deleted) {
+        return { isValid: false, message: Boom.unauthorized('User not found', strategy) };
+    }
+
+    if (!user && credentials.session) {
+        const notSupported = name => {
+            return () => {
+                logger && logger.warn(`user.${name} is not supported for guests`);
+                return false;
+            };
+        };
+        // use non-persistant User model instance
+        user = User.build({
+            role: 'guest',
+            id: undefined,
+            language: 'en-US'
+        });
+        // make sure it never ends up in our DB
+        user.save = notSupported('save');
+        user.update = notSupported('update');
+        user.destroy = notSupported('destroy');
+        user.reload = notSupported('reload');
+    }
+
+    return { isValid: true, credentials, artifacts: user };
+};
+
+
+/**
+ * Generate a sha256 hash from a string. This is used in the PHP API and is needed for backwards
+ * compatibility.
+ *
+ * @param {string} pwhash - value to hash with sha256
+ * @param {string} secret - salt to hash the value with
+ * @returns {string}
+ */
+function legacyHash(pwhash, secret = DEFAULT_SALT) {
+    const hmac = crypto.createHmac('sha256', secret);
+    hmac.update(pwhash);
+    return hmac.digest('hex');
+}
+
+/**
+ * The old PHP API used sha256 to hash passwords with constant salts.
+ * The Node.js API uses bcrypt which is more secure.
+ * It is still important to support the old way for migration purposes since PHP and Node API
+ * will live side by side for some time.
+ * When the PHP Server gets turned off, we can hopefully delete this function.
+ *
+ * @deprecated
+ * @param {string} password - Password string sent from the client (Can be client side hashed or not)
+ * @param {string} passwordHash - Password hash to compare (from DB)
+ * @param {string} authSalt - defined in config.js
+ * @param {string} secretAuthSalt - defined in config.js
+ * @returns {boolean}
+ */
+function legacyLogin(password, passwordHash, authSalt, secretAuthSalt) {
+    let serverHash = secretAuthSalt ? legacyHash(password, secretAuthSalt) : password;
+
+    if (serverHash === passwordHash) return true;
+
+    const clientHash = legacyHash(password, authSalt);
+    serverHash = secretAuthSalt ? legacyHash(clientHash, secretAuthSalt) : clientHash;
+    return serverHash === passwordHash;
+}
+
+/**
+ * Migrate the old sha256 password hash to a more modern and secure bcrypt hash.
+ *
+ * @param {number} userId - ID of the user to migrate
+ * @param {string} password - User password
+ * @param {number} hashRounds - Iteration amout for bcrypt
+ */
+async function migrateHashToBcrypt(userId, password, hashRounds) {
+    const hash = await bcrypt.hash(password, hashRounds);
+
+    await User.update(
+        {
+            pwd: hash
+        },
+        { where: { id: userId } }
+    );
+}
+
+/**
+ * Hash a password with bcrypt. This function doesn't need to be directly imported since it's
+ * exposed on the Hapi server object as server method.
+ *
+ * @example
+ * const hash = await server.methods.hashPassword('hunter2')
+ *
+ * @param {number} hashRounds - Number of rounds for the brypt algorithm
+ */
+function createHashPassword(hashRounds) {
+    return async function hashPassword(password) {
+        return password === '' ? password : bcrypt.hash(password, hashRounds);
+    };
+}
+
+function createComparePassword(server) {
+    /**
+     * Check validity of a password against the saved password hash
+     *
+     * @param {string} password - Plaintext password to check
+     * @param {string} passwordHash - Password hash to compare (from DB)
+     * @param {object} options
+     * @param {number} options.userId - User ID for hash migration
+     * @returns {Boolean}
+     */
+    return async function comparePassword(password, passwordHash, { userId }) {
+        const { api } = server.methods.config();
+        let isValid = false;
+        /**
+         * Bcrypt uses a prefix for versioning. That way a bcrypt hash can be identified with "$2".
+         * https://en.wikipedia.org/wiki/Bcrypt#Description
+         */
+        if (passwordHash.startsWith('$2')) {
+            isValid = await bcrypt.compare(password, passwordHash);
+            /**
+             * Due to the migration from sha256 to bcrypt, the API must deal with sha256 passwords that
+             * got created by the PHP API and migrated from the `migrateHashToBcrypt` function.
+             * The node API get's passwords only in clear text and to compare those with a migrated
+             * password, it first has to generate the former client hashed password.
+             */
+            if (!isValid) {
+                isValid = await bcrypt.compare(legacyHash(password, api.authSalt), passwordHash);
+            }
+        } else {
+            /**
+             * The user password hash was created by the PHP API and is not a bcrypt hash. That means
+             * the API needs to use the old comparison method with double sha256 hashes.
+             */
+            isValid = legacyLogin(password, passwordHash, api.authSalt, api.secretAuthSalt);
+
+            /**
+             * When the old method works, the API migrates the old hash to a bcrypt hash for more
+             * security. This ensures a seemless migration for users.
+             */
+            if (isValid && userId && api.enableMigration) {
+                await migrateHashToBcrypt(userId, password, api.hashRounds);
+            }
+        }
+        return isValid;
+    };
+}
+
+function getStateOpts(
+    server,
+    ttl,
+    sameSite = process.env.NODE_ENV === 'development' ? 'None' : 'Lax'
+) {
+    return {
+        isSecure: server.methods.config('frontend').https,
+        strictHeader: false,
+        domain: `.${server.methods.config('api').domain}`,
+        isSameSite: sameSite,
+        path: '/',
+        ttl: cookieTTL(ttl)
+    };
+}
+
+async function associateChartsWithUser(sessionId, userId) {
+    /* Sequelize returns [0] when no row was updated */
+    if (!sessionId) return [0];
+
+    return Chart.update(
+        {
+            author_id: userId,
+            guest_session: null
+        },
+        {
+            where: {
+                author_id: null,
+                guest_session: sessionId
+            }
+        }
+    );
+}
+
+async function createSession(id, userId, keepSession = true, type = 'password') {
+    return Session.create({
+        id,
+        user_id: userId,
+        persistent: keepSession,
+        data: {
+            'dw-user-id': userId,
+            persistent: keepSession,
+            last_action_time: Math.floor(Date.now() / 1000),
+            type
+        }
+    });
+}
+
+async function bearerValidation(request, token, h) {
+    const row = await AccessToken.findOne({ where: { token, type: 'api-token' } });
+
+    if (!row) {
+        return { isValid: false, message: Boom.unauthorized('Token not found', 'Token') };
+    }
+
+    await row.update({ last_used_at: new Date() });
+
+    const auth = await getUser(row.user_id, {
+        credentials: { token },
+        strategy: 'Token'
+    });
+    if (!auth.artifacts.isActivated()) {
+        // only activated users may authenticate through bearer tokens
+        return { isValid: false, message: Boom.unauthorized('User not activated', 'Token') };
+    }
+    if (auth.isValid) {
+        auth.credentials.scope =
+            !row.data.scopes || row.data.scopes.includes('all')
+                ? request.server.methods.getScopes(auth.artifacts.isAdmin())
+                : row.data.scopes;
+    }
+    return auth;
+}
+
+async function cookieValidation(request, session, h) {
+    let row = await Session.findByPk(session);
+
+    if (!row) {
+        return { isValid: false, message: Boom.unauthorized('Session not found', 'Session') };
+    }
+
+    row = await row.update({
+        data: {
+            ...row.data,
+            last_action_time: Math.floor(Date.now() / 1000)
+        }
+    });
+
+    const auth = await getUser(row.data['dw-user-id'], {
+        credentials: { session, data: row },
+        strategy: 'Session',
+        logger: typeof request.server.logger === 'function' ? request.server.logger() : undefined
+    });
+
+    if (auth.isValid) {
+        if (typeof request.server.methods.getScopes === 'function') {
+            // add all scopes to cookie session
+            auth.credentials.scope = request.server.methods.getScopes(auth.artifacts.isAdmin());
+        }
+
+        auth.sessionType = row.data.type;
+    }
+    return auth;
+}
+
+function createCookieAuthScheme(createGuestSessions) {
+    return function cookieAuth(server, options) {
+        const api = server.methods.config('api');
+        const opts = { cookie: api.sessionID, ...options };
+
+        server.state(opts.cookie, getStateOpts(server, 90));
+
+        const scheme = {
+            authenticate: async (request, h) => {
+                let session = request.state[opts.cookie];
+
+                /**
+                 * Sometimes there are 2 session cookies, in the staging environment, with name
+                 * DW-SESSION. The reason is that the same name is used on live (.datawrapper.de) and
+                 * staging (.staging.datawrapper.de). The cookie parser therefore returns an array with
+                 * both cookies and since the server doesn't send any information which cookie belongs
+                 * to which domain, the code relies on the server sending the more specific cookie
+                 * first. This is fine since it only happens on staging and the quick fix is to delete
+                 * the wrong cookie in dev tools.
+                 *
+                 * More information and a similar issue can be found on Github:
+                 * https://github.com/jshttp/cookie/issues/18#issuecomment-30344206
+                 */
+                if (Array.isArray(session)) {
+                    session = session[0];
+                }
+
+                const {
+                    isValid,
+                    credentials,
+                    artifacts,
+                    sessionType,
+                    message = Boom.unauthorized(null, 'Session')
+                } = await cookieValidation(request, session, h);
+
+                const sameSite = process.env.NODE_ENV === 'development' ? 'None' : 'Lax';
+
+                if (isValid) {
+                    h.state(
+                        opts.cookie,
+                        session,
+                        getStateOpts(server, 90, sessionType === 'token' ? 'None' : sameSite)
+                    );
+                    return h.authenticated({ credentials, artifacts });
+                } else if (createGuestSessions) {
+                    // no cookie or session expired, let's create a new session
+                    const sessionId = generateToken();
+
+                    const session = await Session.create({
+                        id: sessionId,
+                        user_id: null,
+                        persistent: false,
+                        data: {
+                            'dw-user-id': null,
+                            persistent: false,
+                            last_action_time: Math.floor(Date.now() / 1000)
+                        }
+                    });
+
+                    h.state(
+                        opts.cookie,
+                        sessionId,
+                        getStateOpts(server, 90, sessionType === 'token' ? 'None' : sameSite)
+                    );
+
+                    const auth = await getUser('guest', {
+                        credentials: { session: session.id, data: session },
+                        strategy: 'Session'
+                    });
+
+                    return h.authenticated(auth);
+                }
+
+                return message;
+
+                function generateToken(length = 25) {
+                    const alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+                    return generate(alphabet, length);
+                }
+            }
+        };
+
+        return scheme;
+    }
+}
+
+module.exports = {
+    getUser,
+    adminValidation,
+    cookieTTL,
+
+    cookieValidation,
+    createCookieAuthScheme,
+    bearerValidation,
+
+    legacyHash,
+    createHashPassword,
+    createComparePassword,
+    getStateOpts,
+    associateChartsWithUser,
+    createSession
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,6 +129,19 @@
         "arrify": "^1.0.1"
       }
     },
+    "@hapi/boom": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
+      "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/hoek": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
+      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -851,6 +864,11 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
     },
     "binary-extensions": {
       "version": "2.0.0",
@@ -4943,6 +4961,11 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nanoid": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -42,9 +42,12 @@
         "raf": "^3.4.1"
     },
     "dependencies": {
+        "@hapi/boom": "^9.1.0",
+        "bcryptjs": "^2.4.3",
         "chroma-js": "^2.0.3",
         "d3-array": "^1.2.4",
         "lodash-es": "^4.17.15",
+        "nanoid": "^2.1.11",
         "sinon": "^7.3.2",
         "underscore": "^1.9.1"
     },


### PR DESCRIPTION
This PR adds some authentication-related functions that both `api` and `frontend` use to `@datawrapper/shared/node/auth.js`.