### PR TITLE
formatNumber: Ensure that (0.0) etc. parentheses formats are respected

### DIFF
--- a/formatNumber.js
+++ b/formatNumber.js
@@ -44,8 +44,14 @@ export default function(value, options) {
         value *= 0.01;
     }
     value *= multiply;
-    const fmt = numeral(Math.abs(value)).format(format);
-    if (prepend && value < 0 && currencies.has(prepend.trim().toLowerCase())) {
+    const parenthesesFormat = format.indexOf('(') > -1;
+    const fmt = numeral(parenthesesFormat ? value : Math.abs(value)).format(format);
+    if (
+        prepend &&
+        !parenthesesFormat &&
+        value < 0 &&
+        currencies.has(prepend.trim().toLowerCase())
+    ) {
         // pull minus sign to front
         return `${minusChar}${prepend}${fmt.replace('+', '')}${append}`;
     } else if (
@@ -59,7 +65,7 @@ export default function(value, options) {
     } else if (value === 0 && format.includes('+')) {
         return `${prepend}${fmt.replace('+', '±')}${append}`;
     }
-    if (value < 0) {
+    if (value < 0 && !parenthesesFormat) {
         return `${prepend}${minusChar}${fmt.replace('+', '')}${append}`;
     }
     return `${prepend}${fmt}${append}`;


### PR DESCRIPTION
Numeral has a format (X), which formats negative numbers in brackets, instead of with a minus sign

![numeral-format](https://user-images.githubusercontent.com/19191012/106477953-01f4c080-64a9-11eb-94c4-a9fa8cc17d92.png)

The extra logic built in to formatNumber to get unit, sign etc. in the right order, meant that this format was no longer respected.

This PR fixes that by checking for the case that a parentheses format is used and not using this special logic in that case.

I used the simple check of `format.indexOf('(') > -1` because that's how this format is checked for within numeral.js itself.

**Before:**
![image](https://user-images.githubusercontent.com/19191012/106478603-a6770280-64a9-11eb-9e5d-a386b3aabdc4.png)

**After:**
![image](https://user-images.githubusercontent.com/19191012/106478711-c5759480-64a9-11eb-8038-d940a3f7e6c7.png)
