### PR TITLE
Allow to specify a parent for loadStylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ shared.httpReq();
 * [loadScript(src, callback)](#loadScript)
 * [loadStylesheet(src, callback)](#loadStylesheet)
 * [observeFonts(fontsJSON, typographyJSON)](#observeFonts) ⇒ <code>Promise</code>
+* [opts](#opts) : <code>object</code>
 * ~~[patchJSON(url, body, callback)](#patchJSON) ⇒ <code>Promise</code>~~
 * [postEvent(chartId)](#postEvent) ⇒ <code>function</code>
 * ~~[postJSON(url, body, callback)](#postJSON) ⇒ <code>Promise</code>~~
@@ -742,7 +743,7 @@ injects a `<link>` element to the page to load a new stylesheet
 
 | Param | Type |
 | --- | --- |
-| src | <code>string</code> \| <code>object</code> | 
+| src | <code>string</code> \| [<code>opts</code>](#opts) | 
 | callback | <code>function</code> | 
 
 **Example**  
@@ -767,6 +768,19 @@ specified in fontsJSON and typographyJSON have been loaded.
 | --- | --- |
 | fontsJSON | <code>Object</code> \| <code>Array</code> | 
 | typographyJSON | <code>Object</code> | 
+
+
+* * *
+
+<a name="opts"></a>
+
+### opts : <code>object</code>
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| src | <code>string</code> | stylesheet URL to load |
+| parentElement | <code>DOMElement</code> | DOM element to append style tag to |
 
 
 * * *

--- a/README.md
+++ b/README.md
@@ -742,7 +742,7 @@ injects a `<link>` element to the page to load a new stylesheet
 
 | Param | Type |
 | --- | --- |
-| src | <code>string</code> | 
+| src | <code>string</code> \| <code>object</code> | 
 | callback | <code>function</code> | 
 
 **Example**  

--- a/fetch.js
+++ b/fetch.js
@@ -209,7 +209,7 @@ export function loadScript(src, callback = null) {
 /**
  * injects a `<link>` element to the page to load a new stylesheet
  *
- * @param {string} src
+ * @param {string|object} src
  * @param {function} callback
  *
  * @example
@@ -219,16 +219,26 @@ export function loadScript(src, callback = null) {
  *     console.log('library styles are loaded');
  * })
  */
-export function loadStylesheet(src, callback = null) {
+export function loadStylesheet(opts, callback = null) {
+    if (typeof opts === 'string') {
+        opts = {
+            src: opts
+        };
+    }
+
+    if (!opts.parentElement || typeof opts.parentElement.appendChild !== 'function') {
+        opts.parentElement = document.head;
+    }
+
     return new Promise((resolve, reject) => {
         const link = document.createElement('link');
         link.rel = 'stylesheet';
-        link.href = src;
+        link.href = opts.src;
         link.onload = () => {
             if (callback) callback();
             resolve();
         };
         link.onerror = reject;
-        document.head.appendChild(link);
+        opts.parentElement.appendChild(link);
     });
 }

--- a/fetch.js
+++ b/fetch.js
@@ -207,9 +207,15 @@ export function loadScript(src, callback = null) {
 }
 
 /**
+ * @typedef {object} opts
+ * @property {string} src - stylesheet URL to load
+ * @property {DOMElement} parentElement - DOM element to append style tag to
+ */
+
+/**
  * injects a `<link>` element to the page to load a new stylesheet
  *
- * @param {string|object} src
+ * @param {string|opts} src
  * @param {function} callback
  *
  * @example

--- a/package-lock.json
+++ b/package-lock.json
@@ -3091,6 +3091,11 @@
       "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
       "dev": true
     },
+    "fontfaceobserver": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.1.0.tgz",
+      "integrity": "sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng=="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "dependencies": {
         "chroma-js": "^2.0.3",
         "d3-array": "^1.2.4",
+        "fontfaceobserver": "^2.1.0",
         "js-cookie": "^2.2.1",
         "lodash-es": "^4.17.15",
         "numeral": "^2.0.6",


### PR DESCRIPTION
`loadStylesheet(src)` currently appends a `style` tag with the given URL to `document.head`. This PR changes it so that alternatively, you can do this:
```js
loadStylesheet({
    src: '...',
    parentElement: someDOMNode
});
```

The existing notation continues to work and appends to `document.head`.