### PR TITLE
remove lodash-es

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,0 +1,17 @@
+name: lint-and-test
+on: ['push']
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - name: Create npmrc
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{secrets.NPM_TOKEN}}" > ~/.npmrc
+      - name: Install dependencies
+        run: npm ci
+      - name: Code linting
+        run: npm run lint
+      - name: Run tests
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -4085,6 +4085,12 @@
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
           "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
           "dev": true
+        },
+        "underscore": {
+          "version": "1.9.2",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
+          "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==",
+          "dev": true
         }
       }
     },
@@ -4615,11 +4621,6 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
-    },
-    "lodash-es": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -7294,9 +7295,9 @@
       }
     },
     "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
+      "integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -46,10 +46,9 @@
         "d3-array": "^1.2.4",
         "fontfaceobserver": "^2.1.0",
         "js-cookie": "^2.2.1",
-        "lodash-es": "^4.17.15",
         "numeral": "^2.0.6",
         "sinon": "^7.3.2",
-        "underscore": "^1.9.1"
+        "underscore": "^1.12.0"
     },
     "lint-staged": {
         "*.js": [

--- a/significantDimension.js
+++ b/significantDimension.js
@@ -1,7 +1,7 @@
 import tailLength from './tailLength';
 import round from './round';
-import uniq from 'lodash-es/uniq';
-import _isFinite from 'lodash-es/isFinite';
+import uniq from 'underscore/modules/uniq';
+import _isFinite from 'underscore/modules/isFinite';
 
 /**
  * computes the significant dimension for a list of numbers


### PR DESCRIPTION
I think we should be using `underscore` instead of `lodash-es`, now that it's modularized.