### PR TITLE
Add sports season format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1798,6 +1798,11 @@
         "time-zone": "^1.0.0"
       }
     },
+    "dayjs": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "dependencies": {
         "chroma-js": "^2.0.3",
         "d3-array": "^1.2.4",
+        "dayjs": "^1.10.4",
         "fontfaceobserver": "^2.1.0",
         "js-cookie": "^2.2.1",
         "numeral": "^2.0.6",

--- a/sportsSeasonFormat.js
+++ b/sportsSeasonFormat.js
@@ -9,7 +9,7 @@ export default (o, c) => {
         const str = formatStr || FORMAT_DEFAULT;
         const separator = this.$locale().seasonSeparator || '-';
 
-        const result = str.replace(/(\[[^\]]+])|SS|S/g, (match, a) => {
+        const result = str.replace(/(\[[^\]]+])|(?<!S)S{1,2}(?!S)/g, (match, a) => {
             const year = this.$y;
             const nextYear = year + 1;
             const shortFmt = match === 'S';

--- a/sportsSeasonFormat.js
+++ b/sportsSeasonFormat.js
@@ -1,0 +1,27 @@
+import { FORMAT_DEFAULT } from 'dayjs/esm/constant';
+
+export default (o, c) => {
+    // locale needed later
+    const proto = c.prototype;
+    const oldFormat = proto.format;
+    // extend en locale here
+    proto.format = function(formatStr) {
+        const str = formatStr || FORMAT_DEFAULT;
+        const separator = this.$locale().seasonSeparator || '-';
+
+        const result = str.replace(/(\[[^\]]+])|SS|S/g, (match, a) => {
+            const year = this.$y;
+            const nextYear = year + 1;
+            const shortFmt = match === 'S';
+            const args1 = shortFmt ? [String(year).slice(-2), 2] : [year, 4];
+            const args2 = [String(nextYear).slice(-2), 2];
+            return (
+                a ||
+                `${shortFmt ? "'" : ''}${this.$utils().s(...args1, '0')}${separator}${
+                    shortFmt ? "'" : ''
+                }${this.$utils().s(...args2, '0')}`
+            );
+        });
+        return oldFormat.bind(this)(result);
+    };
+};


### PR DESCRIPTION
### Motivation

https://www.notion.so/datawrapper/Season-format-for-axis-tick-labels-13fd3d7671ac47b78a51379cea534861

Original PR from Gregor: https://github.com/datawrapper/plugin-d3-lines/pull/79#issue-594819706

I slightly modified the suggestion so that the season separator (the `-` in `2005-06`) is configurable on locale level, as `2005/06` is the common Notation in German.