### PR TITLE
don't use lookbehind in sportSeasonFormat

### DIFF
--- a/sportsSeasonFormat.js
+++ b/sportsSeasonFormat.js
@@ -9,7 +9,7 @@ export default (o, c) => {
         const str = formatStr || FORMAT_DEFAULT;
         const separator = this.$locale().seasonSeparator || '-';
 
-        const result = str.replace(/(\[[^\]]+])|(?<!S)S{1,2}(?!S)/g, (match, a) => {
+        const result = str.replace(/(\[[^\]]+])|SS|S/g, (match, a) => {
             const year = this.$y;
             const nextYear = year + 1;
             const shortFmt = match === 'S';


### PR DESCRIPTION
Turns out the lookbehind used in the `sportsSeasonFormat` isn't supported by safari or IE. so we will revert to SS|S which does collide with existing milliseconds format SSS, but that should be on ok sacrifice to make for now given the urgency of the bug.