### PR TITLE
get,set: Support array of strings as the 'key' arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ way doesn't exist.
 | Param | Type | Description |
 | --- | --- | --- |
 | object |  | the object which properties you want to acccess |
-| key | <code>String</code> | dot-separated keys aka "path" to the property |
+| key | <code>String</code> \| <code>Array.&lt;String&gt;</code> | path to the property as a dot-separated string or array of strings |
 | _default | <code>\*</code> | the fallback value to be returned if key doesn't exist |
 
 **Example**  
@@ -948,7 +948,7 @@ way doesn't exist.
 | Param | Type | Description |
 | --- | --- | --- |
 | object |  | the object which properties you want to acccess |
-| key | <code>String</code> | dot-separated keys aka "path" to the property |
+| key | <code>String</code> \| <code>Array.&lt;String&gt;</code> | path to the property as a dot-separated string or array of strings |
 | value | <code>\*</code> | the value to be set |
 
 

--- a/get.js
+++ b/get.js
@@ -8,7 +8,7 @@
  *
  *
  * @param object - the object which properties you want to acccess
- * @param {String} key - dot-separated keys aka "path" to the property
+ * @param {String|String[]} key - path to the property as a dot-separated string or array of strings
  * @param {*} _default - the fallback value to be returned if key doesn't exist
  *
  * @returns the value
@@ -22,8 +22,7 @@
  */
 export default function get(object, key = null, _default = null) {
     if (!key) return object;
-    // expand keys
-    const keys = key.split('.');
+    const keys = Array.isArray(key) ? key : key.split('.');
     let pt = object;
 
     for (let i = 0; i < keys.length; i++) {

--- a/get.test.js
+++ b/get.test.js
@@ -9,7 +9,8 @@ const thing = {
         array: [1, 2, 4, 8],
         nested: {
             foo: 12
-        }
+        },
+        'sp.am': 'spam'
     }
 };
 
@@ -42,4 +43,8 @@ test('get array elements', t => {
 
 test('get array elements fallback', t => {
     t.is(get(thing, 'nested.array.4', 'unknown'), 'unknown');
+});
+
+test('get using a key as array', t => {
+    t.is(get(thing, ['nested', 'sp.am']), 'spam');
 });

--- a/set.js
+++ b/set.js
@@ -7,13 +7,13 @@
  * @kind function
  *
  * @param object - the object which properties you want to acccess
- * @param {String} key - dot-separated keys aka "path" to the property
+ * @param {String|String[]} key - path to the property as a dot-separated string or array of strings
  * @param {*} value - the value to be set
  *
  * @returns the value
  */
 export default function set(object, key, value) {
-    const keys = key.split('.');
+    const keys = Array.isArray(key) ? key : key.split('.');
     const lastKey = keys.pop();
     let pt = object;
 

--- a/set.test.js
+++ b/set.test.js
@@ -55,3 +55,8 @@ test('set returns true if something changed', t => {
     t.true(set(thing, 'nested.bar', false));
     t.false(set(thing, 'nested.bar', false));
 });
+
+test('set using a key as array', t => {
+    set(thing, ['nested', 'sp.am'], 'spam');
+    t.is(thing['nested']['sp.am'], 'spam');
+});


### PR DESCRIPTION
#### Motivation

In the new map data upload, we are doing this:

``` js
chart.getMetadata(`data.column-format.${columnName}.type`);
```

But that's unsecure, because `columnName` can contain a dot.

We should rather do this:

``` js
chart.getMetadata(['data', 'column-format', columnName, 'type']);
```

#### Changes

Add support for the `key` argument of `get()` and `set()` to be an array of strings.