### PR TITLE
take defined fontFamilies into account when determining which fonts to wait for

### DIFF
--- a/observeFonts.js
+++ b/observeFonts.js
@@ -17,8 +17,11 @@ export default function observeFonts(fontsJSON, typographyJSON) {
 
     Object.keys(typographyJSON.fontFamilies || {}).forEach(fontFamily => {
         typographyJSON.fontFamilies[fontFamily].forEach(fontface => {
+            /* If this font is being used in a font family */
             if (fonts.has(fontface.name)) {
+                /* Remove it form the list of fonts to wait for */
                 fonts.delete(fontface.name);
+                /* And add it again with theme-defined weight and style */
                 fonts.add({
                     family: fontFamily,
                     props: {

--- a/observeFonts.js
+++ b/observeFonts.js
@@ -13,27 +13,13 @@ import FontFaceObserver from 'fontfaceobserver';
  */
 export default function observeFonts(fontsJSON, typographyJSON) {
     /* Render vis again after fonts have been loaded */
-
-    let fonts = Array.isArray(fontsJSON)
-        ? []
-        : Object.keys(fontsJSON).map(font => {
-              return {
-                  family: font,
-                  props: {
-                      weight: 400,
-                      style: 'normal'
-                  }
-              };
-          });
+    const fonts = new Set(Array.isArray(fontsJSON) ? [] : Object.keys(fontsJSON));
 
     Object.keys(typographyJSON.fontFamilies || {}).forEach(fontFamily => {
         typographyJSON.fontFamilies[fontFamily].forEach(fontface => {
-            /* if this font is being used inside of a font family */
-            if (fonts.filter(f => f.family === fontface.name).length) {
-                /* remove it from the list of fonts */
-                fonts = fonts.filter(f => f.family !== fontface.name);
-                /* and add it again with theme-defined weight and style */
-                fonts.push({
+            if (fonts.has(fontface.name)) {
+                fonts.delete(fontface.name);
+                fonts.add({
                     family: fontFamily,
                     props: {
                         weight: fontface.weight || 400,
@@ -44,33 +30,12 @@ export default function observeFonts(fontsJSON, typographyJSON) {
         });
     });
 
-    /* also check for fonts used in theme */
-    Object.keys(typographyJSON).forEach(key => {
-        if (typographyJSON[key].typeface) {
-            const font = {
-                family: typographyJSON[key].typeface.split(',')[0].replace(/['"]/gm, ''),
-                props: {
-                    weight: typographyJSON[key].fontWeight || 400,
-                    style: typographyJSON[key].cursive ? 'italic' : 'normal'
-                }
-            };
-            if (!fontAlreadyRegistered(font)) fonts.push(font);
-        }
-    });
-
-    function fontAlreadyRegistered(font) {
-        return fonts.filter(f => {
-            return (
-                f.family === font.family &&
-                f.props.weight === font.props.weight &&
-                f.props.style === font.props.style
-            );
-        }).length;
-    }
-
     const observers = [];
     fonts.forEach(font => {
-        const obs = new FontFaceObserver(font.family, font.props);
+        const obs =
+            typeof font === 'string'
+                ? new FontFaceObserver(font)
+                : new FontFaceObserver(font.family, font.props);
         observers.push(obs.load(null, 5000));
     });
 

--- a/observeFonts.js
+++ b/observeFonts.js
@@ -13,23 +13,13 @@ import FontFaceObserver from 'fontfaceobserver';
  */
 export default function observeFonts(fontsJSON, typographyJSON) {
     /* Render vis again after fonts have been loaded */
-    let fonts = Array.isArray(fontsJSON)
-        ? []
-        : Object.keys(fontsJSON).map(font => {
-              return {
-                  family: font,
-                  props: {
-                      weight: 400,
-                      style: 'normal'
-                  }
-              };
-          });
+    const fonts = new Set(Array.isArray(fontsJSON) ? [] : Object.keys(fontsJSON));
 
     Object.keys(typographyJSON.fontFamilies || {}).forEach(fontFamily => {
         typographyJSON.fontFamilies[fontFamily].forEach(fontface => {
-            if (fonts.map(f => f.family).includes(fontface.name)) {
-                fonts = fonts.filter(f => f.family !== fontface.name);
-                fonts.push({
+            if (fonts.has(fontface.name)) {
+                fonts.delete(fontface.name);
+                fonts.add({
                     family: fontFamily,
                     props: {
                         weight: fontface.weight || 400,
@@ -42,7 +32,10 @@ export default function observeFonts(fontsJSON, typographyJSON) {
 
     const observers = [];
     fonts.forEach(font => {
-        const obs = new FontFaceObserver(font.family, font.props);
+        const obs =
+            typeof font === 'string'
+                ? new FontFaceObserver(font)
+                : new FontFaceObserver(font.family, font.props);
         observers.push(obs.load(null, 5000));
     });
 


### PR DESCRIPTION
### Motivation
The current implementation of `observeFonts` waits for all of the fonts defined in the theme's `fontsJSON`. If however, any of those fonts have been used as part of a font family via `typography.fontFamilies`, then they no longer exist as a font family of their own.

e.g
if a theme has:

```
  "fontFamilies": {
      "SpiegelSans4": [
          {
              "name": "SpiegelSans4-Regular",
              "style": "normal",
              "weight": 400
          },
          {
              "name": "SpiegelSans4-Bold",
              "style": "normal",
              "weight": 700
          }
      ]
  }
```

Then the font family `SpiegelSans4-Regular` doesn't exist anymore, but `observeFonts` still tries to wait for it, and times out after 5s. This means that in some cases, it's a 5 second wait before a chart rerenders with correct font measurements, which is visible and looks strange, and also means that exports can have cut off labels.

### Changes
Don't include fonts that are used within fontFamilies in the set of fonts to be waited for, but do include them with correct name and weight/style as defined in the theme.

I also got rid of the loop through the `typography` keys (`headline`, `description` etc.) because if a font is used in the theme it should anyway exist in the theme `fontJSON`. Yes, this excludes different/weights styles for import cases, but that was already the case.

Nicer would be if we only waited for fonts that are actually required for the given render.