### PR TITLE
Upgrade underscore to v13.1

### DIFF
--- a/dateColumnFormatter.js
+++ b/dateColumnFormatter.js
@@ -1,4 +1,4 @@
-import { isDate, identity } from 'underscore/modules';
+import { isDate, identity } from 'underscore';
 import dayjs from 'dayjs';
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.32.5",
             "license": "MIT",
             "dependencies": {
-                "chroma-js": "^2.0.3",
+                "chroma-js": "2.0.2",
                 "d3-array": "^1.2.4",
                 "fontfaceobserver": "^2.1.0",
                 "js-cookie": "^2.2.1",
@@ -1389,12 +1389,9 @@
             }
         },
         "node_modules/chroma-js": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.1.1.tgz",
-            "integrity": "sha512-gYc5/Dooshun2OikK7oY/hYnoEiZ0dxqRpXosEdYRYm505vU5mRsHFqIW062C9nMtr32DVErP6mlxuepo2kNkw==",
-            "dependencies": {
-                "cross-env": "^6.0.3"
-            }
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.0.2.tgz",
+            "integrity": "sha512-VtDXaYcaDr45wheOXasIs4S4IWEjpqh74UfQA0TwoLuBR7TG12ztmjj9JqTIe1sgzVTMDNwSPEJYcw/jYK2TSw=="
         },
         "node_modules/chunkd": {
             "version": "2.0.1",
@@ -1953,75 +1950,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/cross-env": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
-            "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
-            "dependencies": {
-                "cross-spawn": "^7.0.0"
-            },
-            "bin": {
-                "cross-env": "src/bin/cross-env.js",
-                "cross-env-shell": "src/bin/cross-env-shell.js"
-            },
-            "engines": {
-                "node": ">=8.0"
-            }
-        },
-        "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-            "dependencies": {
-                "path-key": "^3.1.0",
-                "shebang-command": "^2.0.0",
-                "which": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/cross-spawn/node_modules/path-key": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cross-spawn/node_modules/shebang-command": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dependencies": {
-                "shebang-regex": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cross-spawn/node_modules/shebang-regex": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cross-spawn/node_modules/which": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "node-which": "bin/node-which"
-            },
-            "engines": {
-                "node": ">= 8"
             }
         },
         "node_modules/crypto-random-string": {
@@ -4635,6 +4563,7 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/isobject": {
@@ -9899,12 +9828,9 @@
             }
         },
         "chroma-js": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.1.1.tgz",
-            "integrity": "sha512-gYc5/Dooshun2OikK7oY/hYnoEiZ0dxqRpXosEdYRYm505vU5mRsHFqIW062C9nMtr32DVErP6mlxuepo2kNkw==",
-            "requires": {
-                "cross-env": "^6.0.3"
-            }
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.0.2.tgz",
+            "integrity": "sha512-VtDXaYcaDr45wheOXasIs4S4IWEjpqh74UfQA0TwoLuBR7TG12ztmjj9JqTIe1sgzVTMDNwSPEJYcw/jYK2TSw=="
         },
         "chunkd": {
             "version": "2.0.1",
@@ -10291,52 +10217,6 @@
                     "requires": {
                         "caller-path": "^2.0.0",
                         "resolve-from": "^3.0.0"
-                    }
-                }
-            }
-        },
-        "cross-env": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
-            "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
-            "requires": {
-                "cross-spawn": "^7.0.0"
-            }
-        },
-        "cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-            "requires": {
-                "path-key": "^3.1.0",
-                "shebang-command": "^2.0.0",
-                "which": "^2.0.1"
-            },
-            "dependencies": {
-                "path-key": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-                },
-                "shebang-command": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-                    "requires": {
-                        "shebang-regex": "^3.0.0"
-                    }
-                },
-                "shebang-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-                },
-                "which": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-                    "requires": {
-                        "isexe": "^2.0.0"
                     }
                 }
             }
@@ -12094,7 +11974,8 @@
             "dev": true
         },
         "isexe": {
-            "version": "2.0.0"
+            "version": "2.0.0",
+            "dev": true
         },
         "isobject": {
             "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7300,9 +7300,9 @@
       }
     },
     "underscore": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
-      "integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.32.5",
             "license": "MIT",
             "dependencies": {
-                "chroma-js": "2.0.2",
+                "chroma-js": "^2.1.2",
                 "d3-array": "^1.2.4",
                 "fontfaceobserver": "^2.1.0",
                 "js-cookie": "^2.2.1",
@@ -1389,9 +1389,12 @@
             }
         },
         "node_modules/chroma-js": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.0.2.tgz",
-            "integrity": "sha512-VtDXaYcaDr45wheOXasIs4S4IWEjpqh74UfQA0TwoLuBR7TG12ztmjj9JqTIe1sgzVTMDNwSPEJYcw/jYK2TSw=="
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.1.2.tgz",
+            "integrity": "sha512-ri/ouYDWuxfus3UcaMxC1Tfp3IE9K5iQzxc2hSxbBRVNQFut1UuGAsZmiAf2mOUubzGJwgMSv9lHg+XqLaz1QQ==",
+            "dependencies": {
+                "cross-env": "^6.0.3"
+            }
         },
         "node_modules/chunkd": {
             "version": "2.0.1",
@@ -1952,6 +1955,75 @@
                 "node": ">=4"
             }
         },
+        "node_modules/cross-env": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
+            "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
+            "dependencies": {
+                "cross-spawn": "^7.0.0"
+            },
+            "bin": {
+                "cross-env": "src/bin/cross-env.js",
+                "cross-env-shell": "src/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/cross-spawn/node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cross-spawn/node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cross-spawn/node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cross-spawn/node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/crypto-random-string": {
             "version": "2.0.0",
             "dev": true,
@@ -2173,14 +2245,6 @@
                 "pkg-config": "^1.1.0",
                 "run-parallel": "^1.1.2",
                 "uniq": "^1.0.1"
-            }
-        },
-        "node_modules/deglob/node_modules/ignore": {
-            "version": "5.0.6",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
             }
         },
         "node_modules/del": {
@@ -2928,14 +2992,6 @@
             },
             "peerDependencies": {
                 "eslint": ">=4.19.1"
-            }
-        },
-        "node_modules/eslint-plugin-node/node_modules/ignore": {
-            "version": "5.0.6",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
             }
         },
         "node_modules/eslint-plugin-promise": {
@@ -4563,7 +4619,6 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/isobject": {
@@ -4736,17 +4791,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/jsdoc/node_modules/marked": {
-            "version": "0.7.0",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "marked": "bin/marked"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/jsdoc/node_modules/strip-json-comments": {
@@ -9828,9 +9872,12 @@
             }
         },
         "chroma-js": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.0.2.tgz",
-            "integrity": "sha512-VtDXaYcaDr45wheOXasIs4S4IWEjpqh74UfQA0TwoLuBR7TG12ztmjj9JqTIe1sgzVTMDNwSPEJYcw/jYK2TSw=="
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.1.2.tgz",
+            "integrity": "sha512-ri/ouYDWuxfus3UcaMxC1Tfp3IE9K5iQzxc2hSxbBRVNQFut1UuGAsZmiAf2mOUubzGJwgMSv9lHg+XqLaz1QQ==",
+            "requires": {
+                "cross-env": "^6.0.3"
+            }
         },
         "chunkd": {
             "version": "2.0.1",
@@ -10221,6 +10268,52 @@
                 }
             }
         },
+        "cross-env": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
+            "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
+            "requires": {
+                "cross-spawn": "^7.0.0"
+            }
+        },
+        "cross-spawn": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "requires": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "dependencies": {
+                "path-key": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+                },
+                "shebang-command": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                    "requires": {
+                        "shebang-regex": "^3.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
         "crypto-random-string": {
             "version": "2.0.0",
             "dev": true
@@ -10376,12 +10469,6 @@
                 "pkg-config": "^1.1.0",
                 "run-parallel": "^1.1.2",
                 "uniq": "^1.0.1"
-            },
-            "dependencies": {
-                "ignore": {
-                    "version": "5.0.6",
-                    "dev": true
-                }
             }
         },
         "del": {
@@ -10919,12 +11006,6 @@
                 "minimatch": "^3.0.4",
                 "resolve": "^1.8.1",
                 "semver": "^5.5.0"
-            },
-            "dependencies": {
-                "ignore": {
-                    "version": "5.0.6",
-                    "dev": true
-                }
             }
         },
         "eslint-plugin-promise": {
@@ -11974,8 +12055,7 @@
             "dev": true
         },
         "isexe": {
-            "version": "2.0.0",
-            "dev": true
+            "version": "2.0.0"
         },
         "isobject": {
             "version": "3.0.1",
@@ -12045,10 +12125,6 @@
                 },
                 "escape-string-regexp": {
                     "version": "2.0.0",
-                    "dev": true
-                },
-                "marked": {
-                    "version": "0.7.0",
                     "dev": true
                 },
                 "strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "js-cookie": "^2.2.1",
         "numeral": "^2.0.6",
         "sinon": "^7.3.2",
-        "underscore": "^1.12.0"
+        "underscore": "^1.13.1"
     },
     "lint-staged": {
         "*.js": [

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "raf": "^3.4.1"
     },
     "dependencies": {
-        "chroma-js": "^2.0.3",
+        "chroma-js": "2.0.2",
         "d3-array": "^1.2.4",
         "fontfaceobserver": "^2.1.0",
         "js-cookie": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "raf": "^3.4.1"
     },
     "dependencies": {
-        "chroma-js": "2.0.2",
+        "chroma-js": "^2.1.2",
         "d3-array": "^1.2.4",
         "fontfaceobserver": "^2.1.0",
         "js-cookie": "^2.2.1",

--- a/significantDimension.js
+++ b/significantDimension.js
@@ -1,7 +1,6 @@
 import tailLength from './tailLength';
 import round from './round';
-import uniq from 'underscore/modules/uniq';
-import _isFinite from 'underscore/modules/isFinite';
+import { uniq, isFinite } from 'underscore';
 
 /**
  * computes the significant dimension for a list of numbers
@@ -22,7 +21,7 @@ import _isFinite from 'underscore/modules/isFinite';
 export default function significantDimension(values, tolerance = 0.1) {
     let result = [];
     let decimals = 0;
-    const uniqValues = uniq(values.filter(_isFinite));
+    const uniqValues = uniq(values.filter(isFinite));
     const totalUniq = uniqValues.length;
     let check, diff;
 


### PR DESCRIPTION
There's a new ~~major~~ minor version of Underscore that changes internal path structure. This causes issues with the way we import shared files that rely on `underscore` & `@datawrapper/shared`.

This PR only upgrades underscore for this repo, which we'd have to upgrade in other projects as well. Long term we should consider defining `peerDependencies` with a specific version, or provide bundles for libs.