### PR TITLE
Include thousand separator in default number formatter

### DIFF
--- a/numberColumnFormatter.js
+++ b/numberColumnFormatter.js
@@ -54,7 +54,7 @@ export default function(config) {
             digits = Number(_fmt.substr(1, _fmt.length));
         }
 
-        let numeralFormat = '0';
+        let numeralFormat = '0,0';
         for (var i = 0; i < digits; i++) {
             if (i === 0) numeralFormat += '.';
             numeralFormat += '0';

--- a/numberColumnFormatter.test.js
+++ b/numberColumnFormatter.test.js
@@ -33,7 +33,7 @@ test('format number with significant digits', t => {
     t.is(formatter(1), '1.000');
     t.is(formatter(3.14), '3.14');
     t.is(formatter(3.145675), '3.15');
-    t.is(formatter(122445.56), '122446');
+    t.is(formatter(122445.56), '122,446');
 });
 
 test('autoformat number with prepend & append', t => {
@@ -47,5 +47,5 @@ test('autoformat number with prepend & append', t => {
     t.is(formatter(1, true), 'ca. 1 US$'.replace(/ /g, '\u00A0'));
     t.is(formatter(3.14, true), 'ca. 3.14 US$'.replace(/ /g, '\u00A0'));
     t.is(formatter(3.145675, true), 'ca. 3.145675 US$'.replace(/ /g, '\u00A0'));
-    t.is(formatter(122445.56, true), 'ca. 122445.56 US$'.replace(/ /g, '\u00A0'));
+    t.is(formatter(122445.56, true), 'ca. 122,445.56 US$'.replace(/ /g, '\u00A0'));
 });


### PR DESCRIPTION
For backwards-compatibility with `Globalize`, we need to include the thousand-separator in the number format