### PR TITLE
Move dayjs from devDependencies to dependencies

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -5,7 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
       - name: Create npmrc
         run: |
           echo "//registry.npmjs.org/:_authToken=${{secrets.NPM_TOKEN}}" > ~/.npmrc

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
                 "browser-env": "^3.2.6",
                 "chalk": "^2.4.2",
                 "d3-interpolate": "^1.3.2",
-                "dayjs": "^1.10.4",
                 "esm": "3.2.25",
                 "healthier": "^2.0.0",
                 "husky": "^1.3.1",
@@ -2112,11 +2111,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/dayjs": {
-            "version": "1.10.4",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/debug": {
             "version": "4.1.1",
@@ -10376,10 +10370,6 @@
             "requires": {
                 "time-zone": "^1.0.0"
             }
-        },
-        "dayjs": {
-            "version": "1.10.4",
-            "dev": true
         },
         "debug": {
             "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
         "browser-env": "^3.2.6",
         "chalk": "^2.4.2",
         "d3-interpolate": "^1.3.2",
-        "dayjs": "^1.10.4",
         "esm": "3.2.25",
         "healthier": "^2.0.0",
         "husky": "^1.3.1",
@@ -50,6 +49,9 @@
         "numeral": "^2.0.6",
         "sinon": "^7.3.2",
         "underscore": "^1.13.1"
+    },
+    "peerDependencies": {
+        "dayjs": "^1.10.4"
     },
     "lint-staged": {
         "*.js": [


### PR DESCRIPTION
So that `dayjs` gets installed when using `@datawrapper/shared/columnFormatter` in production. `dayjs` gets [imported by `dateColumnFormatter`](https://github.com/datawrapper/shared/blob/master/dateColumnFormatter.js#L2), which in turn gets [imported by `columnFormatter`](https://github.com/datawrapper/shared/blob/master/columnFormatter.js#L1).