### PR TITLE
Add drawPattern helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ shared.httpReq();
 * [dateColumnFormatter(column)](#dateColumnFormatter) ⇒ <code>function</code>
 * [defaultColors(theme)](#defaultColors) ⇒ <code>\*</code>
 * ~~[deleteJSON(url, callback)](#deleteJSON) ⇒ <code>Promise</code>~~
+* [drawPattern(parameters)](#drawPattern)
 * [equalish(a, b)](#equalish) ⇒ <code>boolean</code>
 * [escapeHtml(unsafe)](#escapeHtml) ⇒ <code>string</code>
 * [estimateTextWidth(text, fontSize)](#estimateTextWidth) ⇒ <code>number</code>
@@ -381,6 +382,19 @@ deleteJSON('http://api.example.org/chart/123').then(() => {
     console.log('deleted!')
 });
 ```
+
+* * *
+
+<a name="drawPattern"></a>
+
+### drawPattern(parameters)
+draws a configurable pattern into an svg pattern def, so that it can be used as a fill
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| parameters | <code>\*</code> | - style parameters for the pattern |
+
 
 * * *
 

--- a/drawPattern.js
+++ b/drawPattern.js
@@ -27,7 +27,7 @@ export default function drawPattern({
     const patternWidth = (lineGap + strokeWidth) * scale;
     let rot = patternRotation[patternType] || 0;
     if (flipV) {
-        rot = 180 - rotation;
+        rot = 180 - rot;
     }
     defs.append('pattern')
         .attr('id', id)

--- a/drawPattern.js
+++ b/drawPattern.js
@@ -1,0 +1,45 @@
+const patternRotation = {
+    horizontal: 90,
+    vertical: 0,
+    'diagonal-up': 135,
+    'diagonal-down': 45
+};
+
+/**
+ * draws a configurable pattern into an svg pattern def, so that it can be used as a fill
+ *
+ * @exports drawPattern
+ * @kind function
+ *
+ * @param {*} parameters -- style parameters for the pattern
+ */
+export default function drawPattern({
+    defs,
+    id,
+    stroke = 'black',
+    strokeWidth = 1,
+    lineGap = 10,
+    patternType = 'horizontal',
+    rotation = 0,
+    scale = 1,
+    flipV = false
+}) {
+    const patternWidth = (lineGap + strokeWidth) * scale;
+    let rot = patternRotation[patternType] || 0;
+    if (flipV) {
+        rot = 180 - rotation;
+    }
+    defs.append('pattern')
+        .attr('id', id)
+        .attr('patternTransform', `rotate(${rot - rotation} 0 0)`)
+        .attr('patternUnits', 'userSpaceOnUse')
+        .attr('height', patternWidth)
+        .attr('width', patternWidth)
+        .append('line')
+        .attr('x1', patternWidth / 2)
+        .attr('y1', 0)
+        .attr('x2', patternWidth / 2)
+        .attr('y2', patternWidth)
+        .attr('stroke', stroke)
+        .attr('stroke-width', strokeWidth * scale);
+}


### PR DESCRIPTION
Adds `drawPattern` method that creates an SVG pattern `def` for a configurable pattern style, that can then be used as a `fill` on elements.

To be used by:
- `locator-maps`: https://github.com/datawrapper/plugin-locator-maps/pull/130
- `d3-bars`