### PR TITLE
Don't wait for assets in fontsJSON that aren't fonts

### DIFF
--- a/observeFonts.js
+++ b/observeFonts.js
@@ -13,8 +13,11 @@ import FontFaceObserver from 'fontfaceobserver';
  */
 export default function observeFonts(fontsJSON, typographyJSON) {
     /* Render vis again after fonts have been loaded */
-    const fonts = new Set(Array.isArray(fontsJSON) ? [] : Object.keys(fontsJSON));
-
+    const fonts = new Set(
+        Array.isArray(fontsJSON)
+            ? []
+            : Object.keys(fontsJSON).filter(key => fontsJSON[key].type === 'font')
+    );
     Object.keys(typographyJSON.fontFamilies || {}).forEach(fontFamily => {
         typographyJSON.fontFamilies[fontFamily].forEach(fontface => {
             /* If this font is being used in a font family */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@datawrapper/shared",
-    "version": "0.35.0",
+    "version": "0.35.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@datawrapper/shared",
-            "version": "0.35.0",
+            "version": "0.35.1",
             "license": "MIT",
             "dependencies": {
                 "chroma-js": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@datawrapper/shared",
-    "version": "0.35.0",
+    "version": "0.35.1",
     "description": "shared functions used throughout datawrapper",
     "keywords": [
         "js",


### PR DESCRIPTION
### Motivation
`fontsJSON` is misleadingly actually the entire assets object, so includes things that aren't fonts (e.g image files). We attempt to wait for these to load as fonts, which means that visualizations can end up rerendering after the 5000 timeout for no reason which causes problems in some scenarios.

### Changes
When constructing creating list of fonts to wait for, filter objects in `fontsJSON` by `type === font`